### PR TITLE
Let people delete wallpapers they imported themselves

### DIFF
--- a/Muro/Sources/MuroApp/Components.swift
+++ b/Muro/Sources/MuroApp/Components.swift
@@ -406,6 +406,7 @@ struct WallpaperCard: View {
 
     @State private var hovering = false
     @State private var showMenu = false
+    @State private var confirmDelete = false
 
     var body: some View {
         Color.black
@@ -425,14 +426,15 @@ struct WallpaperCard: View {
             .onHover { hovering = $0 }
             .contentShape(RoundedRectangle(cornerRadius: 16))
             .onTapGesture { store.openPreview(item) }
-            .overlay { if removableDownload { RightClickCatcher { showMenu = true } } }
+            .overlay { if hasContextMenu { RightClickCatcher { showMenu = true } } }
             .popover(isPresented: $showMenu, arrowEdge: .bottom) {
-                GlassMenuList(width: 200, options: [
-                    MenuOption(
-                        title: "Remove Download (\(formatSize(item.sizeBytes)))",
-                        destructive: true
-                    ) { store.removeDownload(item) }
-                ]) { showMenu = false }
+                GlassMenuList(width: 220, options: contextMenuOptions) { showMenu = false }
+            }
+            .alert("Delete \(item.title)?", isPresented: $confirmDelete) {
+                Button("Cancel", role: .cancel) {}
+                Button("Delete", role: .destructive) { store.deleteWallpaper(item) }
+            } message: {
+                Text(deleteWarning)
             }
     }
 
@@ -442,6 +444,43 @@ struct WallpaperCard: View {
     private var removableDownload: Bool {
         item.isDownloaded && item.remote != nil
             && !store.protectedWallpaperIDs.contains(item.id)
+    }
+
+    private var hasContextMenu: Bool { removableDownload || store.isDeletable(item) }
+
+    /// Removing a download and deleting an import are different promises, so
+    /// they stay separate entries rather than one "Remove": the first is a
+    /// space reclaim the user can undo from Explore, the second is permanent.
+    private var contextMenuOptions: [MenuOption] {
+        var options: [MenuOption] = []
+        if removableDownload {
+            options.append(MenuOption(
+                title: "Remove Download (\(formatSize(item.sizeBytes)))",
+                destructive: true
+            ) { store.removeDownload(item) })
+        }
+        if store.isDeletable(item) {
+            options.append(MenuOption(
+                title: "Delete (\(formatSize(item.sizeBytes)))",
+                destructive: true
+            ) {
+                // GlassMenuRow dismisses the popover and runs the action in
+                // the same update, and an alert raised inside that turn races
+                // the popover teardown and gets dropped. The next turn always
+                // presents it.
+                DispatchQueue.main.async { confirmDelete = true }
+            })
+        }
+        return options
+    }
+
+    private var deleteWarning: String {
+        let base = "This deletes the video from your Muro library for good. "
+            + "It came from your own import, so Muro has no copy to restore — "
+            + "re-import the original file if you want it back."
+        guard store.protectedWallpaperIDs.contains(item.id) else { return base }
+        return base + " It's in use right now, so Muro will also take it off "
+            + "your displays, playlists and lock screen."
     }
 
     @ViewBuilder private var titleOverlay: some View {

--- a/Muro/Sources/MuroApp/PreviewView.swift
+++ b/Muro/Sources/MuroApp/PreviewView.swift
@@ -38,6 +38,7 @@ struct PreviewView: View {
     let itemID: String
 
     @State private var showDisplayPopover = false
+    @State private var confirmDelete = false
     @StateObject private var loader = PreviewLoader()
 
     /// Live item — refreshes as downloads/likes/manifest change.
@@ -134,6 +135,19 @@ struct PreviewView: View {
                 fpsToggle(item)
             }
 
+            // Only the user's own imports: a catalog wallpaper is removed
+            // from disk through Library's Remove Download instead, which is
+            // reversible. Grouped with the other utility icons and kept a
+            // button away from Set Wallpaper, so the destructive action is
+            // never flush against the one people reach for by reflex.
+            if store.isDeletable(item) {
+                Button { confirmDelete = true } label: {
+                    barIcon("trash")
+                }
+                .buttonStyle(.plain)
+                .help("Delete this wallpaper from your library")
+            }
+
             HeartButton(item: item, size: 40)
 
             setButton(item)
@@ -156,6 +170,23 @@ struct PreviewView: View {
             RoundedRectangle(cornerRadius: 26, style: .continuous)
                 .strokeBorder(Color.white.opacity(0.14), lineWidth: 1)
         )
+        .alert("Delete \(item.title)?", isPresented: $confirmDelete) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) { store.deleteWallpaper(item) }
+        } message: {
+            Text(deleteWarning(item))
+        }
+    }
+
+    /// Deleting the previewed wallpaper closes this view on its own, because
+    /// the store clears `previewItem` for anything it removes.
+    private func deleteWarning(_ item: WallpaperItem) -> String {
+        let base = "This deletes the video from your Muro library for good. "
+            + "It came from your own import, so Muro has no copy to restore — "
+            + "re-import the original file if you want it back."
+        guard store.protectedWallpaperIDs.contains(item.id) else { return base }
+        return base + " It's in use right now, so Muro will also take it off "
+            + "your displays, playlists and lock screen."
     }
 
     private var backButton: some View {

--- a/Muro/Sources/MuroApp/SettingsView.swift
+++ b/Muro/Sources/MuroApp/SettingsView.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
     @EnvironmentObject var store: AppStore
 
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
+    @State private var confirmDeleteCustom = false
     @AppStorage("showDockIcon") private var showDockIcon = true
     @AppStorage("defaultMode") private var defaultMode = "smooth"
     @AppStorage("autoPauseFullScreen") private var autoPauseFullScreen = true
@@ -162,10 +163,43 @@ struct SettingsView: View {
                                 .buttonStyle(.plain)
                                 .font(.system(size: 12, weight: .semibold))
                                 .foregroundStyle(.white)
+                                .lineLimit(1)
+                                .fixedSize()
                                 .padding(.horizontal, 14)
                                 .padding(.vertical, 5.5)
                                 .glassCapsule(fill: 0.09, stroke: 0.15)
                         }
+                    }
+                    divider
+                    // Its own row: sharing one with the size and Clear squeezed
+                    // the capsule until the label wrapped to two lines, and it
+                    // also sat a pixel away from a destructive button.
+                    row(icon: "folder", tint: .blue, title: "Wallpapers Folder",
+                        subtitle: "Where your video files are stored") {
+                        Button("Show in Finder") { store.revealWallpapersFolder() }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                            .fixedSize()
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 5.5)
+                            .glassCapsule(fill: 0.09, stroke: 0.15)
+                    }
+                    divider
+                    row(icon: "square.and.arrow.down", tint: .orange,
+                        title: "Custom Wallpapers",
+                        subtitle: customSubtitle) {
+                        Button("Delete All") { confirmDeleteCustom = true }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(store.canDeleteCustom ? Color(hex: 0xFF6B6B) : Color.muroSecondary)
+                            .lineLimit(1)
+                            .fixedSize()
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 5.5)
+                            .glassCapsule(fill: 0.09, stroke: 0.15)
+                            .disabled(!store.canDeleteCustom)
                     }
                     divider
                     row(icon: "clock.arrow.circlepath", tint: .brown, title: "Auto-clear memory",
@@ -235,6 +269,18 @@ struct SettingsView: View {
         } message: {
             Text("Removes Muro’s lock-screen selection and copied extension files, then clears downloaded catalog wallpapers except desktop-applied or playlist items. Your own imported videos are kept.")
         }
+        .alert("Delete all custom wallpapers?", isPresented: $confirmDeleteCustom) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete All", role: .destructive) { store.deleteAllCustomWallpapers() }
+        } message: {
+            Text("Permanently deletes the \(store.customEntries.count) wallpapers you imported yourself (\(formatSize(store.customBytes))). Muro has no copy of these, so they can only come back by importing the original files again. Any that are in use will be taken off your displays, playlists and lock screen.")
+        }
+    }
+
+    private var customSubtitle: String {
+        if store.customEntries.isEmpty { return "Videos you imported yourself" }
+        if store.catalog.isEmpty { return "Checking the catalog first…" }
+        return "\(store.customEntries.count) imported · \(formatSize(store.customBytes))"
     }
 
     // MARK: - Pieces

--- a/Muro/Sources/MuroApp/Store.swift
+++ b/Muro/Sources/MuroApp/Store.swift
@@ -844,7 +844,134 @@ final class AppStore: ObservableObject {
         recomputeSize()
     }
 
+    /// True delete for a wallpaper that exists only on this Mac. Unlike
+    /// `removeDownload` there is no catalog copy to pull back, so instead of
+    /// refusing while the wallpaper is in use it clears every reference first
+    /// — displays, playlists, lock screen. Refusing would strand any import
+    /// the user had applied, with no way left to ever remove it.
+    func deleteWallpaper(_ item: WallpaperItem) {
+        guard let entry = item.local, isDeletable(item) else { return }
+        Task { await performDelete([entry]) }
+    }
+
+    /// Every wallpaper the user brought in themselves. Kept separate from
+    /// Clear on purpose: Clear only ever removes things that can come back,
+    /// and an import cannot — there is no catalog copy behind it.
+    var customEntries: [WallpaperEntry] {
+        let remoteIDs = Set(catalog.map(\.id))
+        return manifest.wallpapers.filter {
+            $0.id != BundledWallpaper.id && !remoteIDs.contains($0.id)
+        }
+    }
+
+    var customBytes: Int64 {
+        customEntries.reduce(0) { $0 + $1.sizeBytes }
+    }
+
+    /// An entry counts as custom by being absent from the catalog, so with no
+    /// catalog loaded every download looks like an import. Rather than risk
+    /// deleting wallpapers the user could not get back by mistake, the action
+    /// stands down until Explore has answered.
+    var canDeleteCustom: Bool { !catalog.isEmpty && !customEntries.isEmpty }
+
+    func deleteAllCustomWallpapers() {
+        guard canDeleteCustom else { return }
+        let entries = customEntries
+        Task { await performDelete(entries) }
+    }
+
+    /// Only the user's own imports. Catalog wallpapers have the reversible
+    /// `removeDownload` instead, and the bundled wallpaper ships inside the
+    /// app rather than the library — it reads as an import for as long as the
+    /// catalog has not loaded, so exclude it by id rather than by shape.
+    func isDeletable(_ item: WallpaperItem) -> Bool {
+        item.isDownloaded && item.remote == nil && item.id != BundledWallpaper.id
+    }
+
+    /// Batched so deleting one wallpaper and emptying the whole custom library
+    /// travel the same path — config, lock screen, playlists and manifest are
+    /// each rewritten once no matter how many wallpapers go.
+    private func performDelete(_ entries: [WallpaperEntry]) async {
+        let ids = Set(entries.map(\.id))
+        guard !ids.isEmpty else { return }
+
+        // Unassign before unlinking. Saving config.json trips the engine's
+        // directory watch, so the wallpaper window is torn down while its
+        // file is still present instead of after it disappears.
+        if let all = config.allDisplays?.wallpaperID, ids.contains(all) {
+            config.allDisplays = nil
+        }
+        config.perDisplay = config.perDisplay.filter { !ids.contains($0.value.wallpaperID) }
+        saveConfig()
+
+        for id in ids where lockScreen.activeWallpaperIDs.contains(id) {
+            await clearLockScreenSelections(for: id)
+        }
+
+        for index in playlists.indices {
+            playlists[index].wallpaperIDs.removeAll { ids.contains($0) }
+        }
+        savePlaylists()
+
+        for entry in entries {
+            for relative in [entry.file, entry.efficientFile, entry.previewFile, entry.thumbnail].compactMap({ $0 }) {
+                try? FileManager.default.removeItem(at: root.appendingPathComponent(relative))
+            }
+        }
+        manifest.wallpapers.removeAll { ids.contains($0.id) }
+        try? manifest.save(root: root)
+
+        recentIDs.removeAll { ids.contains($0) }
+        defaults.set(recentIDs, forKey: "recents")
+        if let hero = heroID, ids.contains(hero) { heroID = nil }
+        if let preview = previewItem?.id, ids.contains(preview) { previewItem = nil }
+        recomputeSize()
+    }
+
+    /// Drops any lock-screen selection naming this wallpaper, using only the
+    /// targeted `remove` calls LockScreenService already exposes — nothing
+    /// here touches Apple's wallpaper store directly. The closing sweep is
+    /// deliberately blunt: if a selection still names the wallpaper (a stale
+    /// all-displays entry, or a mix of all-displays and per-display picks),
+    /// clearing every selection beats leaving the lock screen pointed at a
+    /// file that no longer exists.
+    private func clearLockScreenSelections(for id: String) async {
+        guard lockScreen.activeWallpaperIDs.contains(id) else { return }
+        do {
+            if lockScreen.isApplied(wallpaperID: id, target: .all) {
+                try await lockScreen.remove(target: .all)
+            } else {
+                for display in displays
+                where lockScreen.isApplied(wallpaperID: id, target: .display(display.id)) {
+                    try await lockScreen.remove(target: .display(display.id))
+                }
+                if lockScreen.activeWallpaperIDs.contains(id) {
+                    try await lockScreen.remove(target: .all)
+                }
+            }
+        } catch {
+            applyError = error.localizedDescription
+        }
+    }
+
     // MARK: - Files
+
+    /// Where the wallpaper videos themselves live. `Masters/` rather than the
+    /// library root: the root is mostly bookkeeping (library.json,
+    /// config.json, thumbnails), and someone opening this folder is looking
+    /// for the videos.
+    var mastersFolderURL: URL {
+        root.appendingPathComponent("Masters", isDirectory: true)
+    }
+
+    /// Opens Masters/ in Finder, creating it first — a fresh install has no
+    /// Masters folder until the first download or import, and opening a
+    /// missing path just fails silently.
+    func revealWallpapersFolder() {
+        let url = mastersFolderURL
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        NSWorkspace.shared.open(url)
+    }
 
     func videoURL(for item: WallpaperItem, mode: String) -> URL? {
         guard let entry = item.local else { return nil }


### PR DESCRIPTION
## The gap

`Remove Download` is gated on `item.remote != nil`, which is correct for what it is — a cache action, and an import has no remote copy to pull back. But it means a video you imported yourself has **no way out of the library at all**: not from the card menu, not from the preview, not from Settings. On a library made entirely of imports, nothing can be removed from inside the app.

## What this adds

A real delete for imports, in three places:

- **Wallpaper card** right-click → `Delete`
- **Preview pill bar** → trash button, next to the utility icons and deliberately one button away from `Set Wallpaper`
- **Settings → Storage → Custom Wallpapers** → `Delete All`

Plus **Show in Finder** for the `Masters` folder, since there was previously no way to reach the video files from the app.

## Design notes

- **`Remove Download` is untouched.** Catalog wallpapers keep using it. Reclaiming space you can undo and deleting something permanently are different promises, so they stay separate entries rather than merging into one `Remove`.
- **The bundled wallpaper is excluded by id.** It looks exactly like an import whenever the catalog hasn't loaded yet, so shape alone isn't enough to tell them apart.
- **Deleting an in-use wallpaper is allowed**, and clears references first — display assignments, playlists, lock-screen selection — rather than refusing. Refusing would strand any import the user had applied, with no way left to remove it. `config.json` is saved *before* unlinking so the engine's directory watch tears the window down while the file still exists.
- **`Delete All` stands down until the catalog has loaded**, because "custom" means "absent from the catalog" and an empty catalog would make every download look like an import.
- **Lock-screen handling goes through `LockScreenService.remove(target:)` only.** No new code touches Apple's wallpaper store.

## Testing

Built clean with `swift build`. Exercised in a real `.app` build (macOS 26.6, Apple Silicon) against an 80-entry import-only library: deletes went through the card menu, the preview and `Delete All`, the applied wallpaper survived where it should and was correctly unassigned where it shouldn't, and no orphaned files were left behind in `Masters`/`Thumbnails`/`Previews`.

Happy to adjust naming, placement or the confirmation wording.