### PR TITLE
Make Clear reclaim what an import-only library actually accumulates

### DIFF
--- a/Muro/Sources/MuroApp/SettingsView.swift
+++ b/Muro/Sources/MuroApp/SettingsView.swift
@@ -179,7 +179,7 @@ struct SettingsView: View {
 
                 section("STORAGE") {
                     row(icon: "internaldrive", tint: .gray, title: "Library & Cache",
-                        subtitle: "Everything goes except the wallpaper in use") {
+                        subtitle: store.clearStatus ?? "Everything goes except the wallpaper in use") {
                         HStack(spacing: 10) {
                             Text(formatSize(store.libraryBytes))
                                 .font(.system(size: 12, weight: .medium))

--- a/Muro/Sources/MuroApp/Store.swift
+++ b/Muro/Sources/MuroApp/Store.swift
@@ -83,6 +83,9 @@ final class AppStore: ObservableObject {
     @Published var applySurface: ApplySurface = .both
     @Published var heroID: String?
     @Published var libraryBytes: Int64 = 0
+    /// What the last Clear actually did. Shown in Settings, because a Clear
+    /// that frees nothing otherwise looks identical to one that never ran.
+    @Published var clearStatus: String?
     @Published var recentIDs: [String] = []
     @Published var automations: [Automation] = []
     @Published var activePlaylistID: String?
@@ -1164,7 +1167,8 @@ final class AppStore: ObservableObject {
     }
 
     func clearDownloadedCache() {
-        let doomed = clearPlan.removed.map(\.id)
+        let plan = clearPlan
+        let doomed = plan.removed.map(\.id)
         Task {
             // Clear keeps whatever is playing, and the lock-screen wallpaper
             // is in that set. Tearing the lock screen down here contradicted
@@ -1198,9 +1202,31 @@ final class AppStore: ObservableObject {
             recentIDs.removeAll { doomed.contains($0) }
             defaults.set(recentIDs, forKey: "recents")
             if let heroID, doomed.contains(heroID) { self.heroID = nil }
+            // After the delete, so files it has just released are seen as
+            // unreferenced in the same pass.
+            let swept = (try? await Task.detached(priority: .utility, operation: {
+                [root] in try LibraryWriter.sweepOrphans(root: root)
+            }).value) ?? 0
+            clearStatus = Self.clearSummary(plan: plan, swept: swept)
             recomputeSize()
             objectWillChange.send()
         }
+    }
+
+    /// Clear says what it is about to do, but the confirmation cannot predict
+    /// the swept leftovers: those files are not in the manifest, so nothing
+    /// knows their size until they are found. Saying what actually happened is
+    /// the only way that part is ever visible.
+    private static func clearSummary(plan: ClearPlan, swept: Int64) -> String {
+        var parts: [String] = []
+        if !plan.removed.isEmpty {
+            let count = plan.removed.count
+            parts.append("\(count) \(count == 1 ? "wallpaper" : "wallpapers") removed")
+            parts.append("about \(formatSize(plan.bytes + swept)) freed")
+        } else if swept > 0 {
+            parts.append("\(formatSize(swept)) of leftovers swept")
+        }
+        return parts.isEmpty ? "Nothing to clear" : parts.joined(separator: " · ")
     }
 
     /// Manual per-wallpaper space control: delete the local copy of one

--- a/Muro/Sources/MuroKit/LibraryWriter.swift
+++ b/Muro/Sources/MuroKit/LibraryWriter.swift
@@ -58,6 +58,50 @@ public enum LibraryWriter {
     /// The files are read from the manifest on disk rather than from the
     /// caller's copy of the entry, so a variant or preview generated since
     /// that copy was made is deleted too instead of being left behind.
+    /// Deletes asset files that no manifest entry references, and reports how
+    /// many bytes that freed.
+    ///
+    /// Importing writes the video, thumbnail and preview and appends the
+    /// manifest row only at the end, and a download writes its master straight
+    /// to its final path. A crash or a quit in between strands files nothing
+    /// can reach again: no id anywhere names them, so no delete and no Clear
+    /// will ever find them, and they sit there for the life of the library.
+    ///
+    /// That same ordering is why this cannot simply remove everything
+    /// unreferenced. A file with no row yet may be one an import is still
+    /// writing, and `muro-import` can be that import, in another process this
+    /// one cannot see. A file being written keeps a fresh modification date,
+    /// so anything touched within `grace` is spared and only files old enough
+    /// to have outlived any plausible transcode are swept.
+    ///
+    /// Runs inside `update` so it reads the manifest under the same lock every
+    /// other writer takes, and cannot race a row being appended.
+    @discardableResult
+    public static func sweepOrphans(root: URL, grace: TimeInterval = 900) throws -> Int64 {
+        let manager = FileManager.default
+        var freed: Int64 = 0
+        _ = try update(root: root) { manifest in
+            let referenced = Set(manifest.wallpapers.flatMap(\.relativeFiles))
+            let cutoff = Date().addingTimeInterval(-grace)
+            for folder in ["Masters", "Thumbnails", "Previews"] {
+                let directory = root.appendingPathComponent(folder, isDirectory: true)
+                guard let names = try? manager.contentsOfDirectory(atPath: directory.path)
+                else { continue }
+                for name in names where !name.hasPrefix(".") {
+                    guard !referenced.contains("\(folder)/\(name)") else { continue }
+                    let url = directory.appendingPathComponent(name)
+                    let attributes = try? manager.attributesOfItem(atPath: url.path)
+                    if let modified = attributes?[.modificationDate] as? Date, modified > cutoff {
+                        continue
+                    }
+                    let size = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+                    if (try? manager.removeItem(at: url)) != nil { freed += size }
+                }
+            }
+        }
+        return freed
+    }
+
     @discardableResult
     public static func delete(ids: Set<String>, root: URL) throws -> LibraryManifest {
         var doomed: [String] = []

--- a/Muro/Tests/MuroKitTests/LibraryTests.swift
+++ b/Muro/Tests/MuroKitTests/LibraryTests.swift
@@ -266,4 +266,82 @@ final class LibraryTests: XCTestCase {
         let playlists = [Playlist(id: "p1", name: "Empty", wallpaperIDs: [])]
         XCTAssertTrue(PlaylistStore.pruned(playlists, removing: ["a"]).emptied.isEmpty)
     }
+
+    // MARK: - Orphan sweep
+
+    private func write(_ relative: String, bytes: Int, modified: Date? = nil) throws {
+        let url = root.appendingPathComponent(relative)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try Data(count: bytes).write(to: url)
+        if let modified {
+            try FileManager.default.setAttributes(
+                [.modificationDate: modified], ofItemAtPath: url.path
+            )
+        }
+    }
+
+    private func exists(_ relative: String) -> Bool {
+        FileManager.default.fileExists(atPath: root.appendingPathComponent(relative).path)
+    }
+
+    /// The leak this exists to plug: importing writes the video before it
+    /// appends the manifest row, so a crash in between leaves files that no id
+    /// names and therefore nothing can ever reach again.
+    func testSweepRemovesUnreferencedFiles() throws {
+        let old = Date().addingTimeInterval(-3600)
+        try write("Masters/stranded.mov", bytes: 2048, modified: old)
+        try write("Thumbnails/stranded.jpg", bytes: 512, modified: old)
+
+        let freed = try LibraryWriter.sweepOrphans(root: root)
+
+        XCTAssertEqual(freed, 2560)
+        XCTAssertFalse(exists("Masters/stranded.mov"))
+        XCTAssertFalse(exists("Thumbnails/stranded.jpg"))
+    }
+
+    /// The sweep must never touch a wallpaper that is actually in the library,
+    /// including its optional efficient and preview files.
+    func testSweepKeepsReferencedFiles() throws {
+        var kept = entry(id: "keep")
+        kept.efficientFile = "Masters/keep-eff.mov"
+        kept.previewFile = "Previews/keep-p720.mov"
+        var manifest = LibraryManifest()
+        manifest.wallpapers = [kept]
+        try manifest.save(root: root)
+
+        let old = Date().addingTimeInterval(-3600)
+        for relative in kept.relativeFiles { try write(relative, bytes: 128, modified: old) }
+
+        let freed = try LibraryWriter.sweepOrphans(root: root)
+
+        XCTAssertEqual(freed, 0)
+        for relative in kept.relativeFiles { XCTAssertTrue(exists(relative), relative) }
+    }
+
+    /// The dangerous case. A file with no manifest row yet is indistinguishable
+    /// from an import still writing it — and that import can be `muro-import`
+    /// in another process, which this one cannot see. Recent files are spared
+    /// so the sweep cannot delete the very file it is meant to stop leaking.
+    func testSweepSparesFilesStillBeingWritten() throws {
+        try write("Masters/in-progress.mov", bytes: 4096)
+
+        let freed = try LibraryWriter.sweepOrphans(root: root)
+
+        XCTAssertEqual(freed, 0)
+        XCTAssertTrue(exists("Masters/in-progress.mov"))
+    }
+
+    /// A shorter grace must still hold the line: the file ages past the cutoff
+    /// and only then becomes sweepable.
+    func testSweepGraceIsRespected() throws {
+        try write("Masters/aging.mov", bytes: 1024, modified: Date().addingTimeInterval(-30))
+
+        XCTAssertEqual(try LibraryWriter.sweepOrphans(root: root, grace: 60), 0)
+        XCTAssertTrue(exists("Masters/aging.mov"))
+
+        XCTAssertEqual(try LibraryWriter.sweepOrphans(root: root, grace: 10), 1024)
+        XCTAssertFalse(exists("Masters/aging.mov"))
+    }
 }


### PR DESCRIPTION
## The bug

`Clear` only ever matched wallpapers present in the remote catalog, on the reasoning that those can be re-downloaded. That's sound for a catalog-backed library — but in a library made entirely of imported videos **nothing matches**, so the button frees nothing, reports nothing, and reads as broken.

There's a second, worse half. `clearDownloadedCache()` called `lockScreen.clearAll()` **unconditionally**, before doing any of the matching. So a press that removed nothing still rewrote Apple's wallpaper store, restarted `WallpaperAgent`, unregistered the extension and dropped the user's lock-screen wallpaper. That's how I found this: pressing Clear freed 0 bytes and silently cost me my lock-screen setup.

## What this changes

**1. Gate the lock-screen teardown.** New read-only `hasAnyState` on `LockScreenService` (live selection, saved state, store backup, or staged extension files). `clearAll()` now runs only when there is something to tear down. No plist or restore logic is touched.

**2. Clear the dead weight an import-only library does collect:**
- entries whose video file is already gone — they can't play and can't be restored, so the row is clutter
- files under `Masters`/`Thumbnails`/`Previews` that no manifest entry references

The second is what an interrupted import strands: `importVideo` writes the video first and appends the manifest row last, so a crash or a quit in between leaves a file nothing can reach again. I had a stray master + thumbnail + half-written `.sb-e` preview sitting in my library from exactly this.

That same ordering makes the sweep dangerous while writing is in flight, so it **stands down entirely during an import** and spares anything mid-download or mid-variant-generation. Otherwise it would delete the very file it's meant to stop leaking.

**3. Report the result.** The row now shows `25 entries removed - 14 MB freed`, or `Nothing to clear`. The silence was half of why the button felt dead.

## What is deliberately unchanged

Imported videos that still exist are **never** touched, and anything applied or in a playlist is still skipped. The confirmation text is rewritten to describe the new behaviour accurately.

## Heads up on scope

This changes what `Clear` means, and the previous behaviour is marked in-code as a deliberate decision. I've kept the change as conservative as I could — it only adds things that are unreachable or unusable — but if you'd rather this were a separate button, or want the stale-entry prune dropped and only the lock-screen gating kept, say so and I'll rework it.

## Stacked on #4

Built on top of #4 to avoid a conflict in the Settings storage section. Merge that one first; this diff shows only its own changes once #4 lands.

## Testing

Built clean with `swift build`. Exercised in a real `.app` build (macOS 26.6, Apple Silicon) on an 80-entry import-only library: Clear removed 30 stale entries and swept the orphaned files, reported both, and left the applied wallpaper and the lock-screen selection alone when there was nothing to clear.