### PR TITLE
Pause after: pin down the rule and cover it with tests

### DIFF
--- a/Muro/Sources/MuroKit/Engine/EngineController.swift
+++ b/Muro/Sources/MuroKit/Engine/EngineController.swift
@@ -70,8 +70,13 @@ public final class EngineController {
                 NSStringFromRect(screen.frame),
                 "\(entry.id)|\(assignment.mode)",
                 // A wallpaper may carry its own "pause after"; otherwise the
-                // one global setting applies.
-                entry.pauseAfterSeconds ?? config.pauseAfterSeconds
+                // one global setting applies. `PauseAfter` owns the rule,
+                // including the part that is easy to get wrong: a wallpaper
+                // set to zero never freezes and does not fall back.
+                PauseAfter.resolve(
+                    wallpaper: entry.pauseAfterSeconds,
+                    global: config.pauseAfterSeconds
+                )
             )
         }
 

--- a/Muro/Sources/MuroKit/Engine/WallpaperWindowController.swift
+++ b/Muro/Sources/MuroKit/Engine/WallpaperWindowController.swift
@@ -237,7 +237,7 @@ public final class WallpaperWindowController {
     /// sleep, occlusion and the user pause exactly like the rest, and the
     /// wallpaper only actually resumes when every hold is gone.
     public func setPauseAfter(_ seconds: Int?) {
-        let normalized = (seconds ?? 0) > 0 ? seconds : nil
+        let normalized = PauseAfter.normalise(seconds)
         guard normalized != pauseAfterSeconds else { return }
         pauseAfterSeconds = normalized
         armSettleTimer()

--- a/Muro/Sources/MuroKit/PauseAfter.swift
+++ b/Muro/Sources/MuroKit/PauseAfter.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// How long a wallpaper keeps moving before it freezes on a frame.
+///
+/// Issue #3: "I like to have some wallpapers that can move too fast from time
+/// to times and it's disturbing when I'm focus on something... when it changes
+/// wallpaper or it gets unlocked, then it keeps moving for x sec then pause."
+///
+/// The rule has one trap in it, and this type exists so that trap is written
+/// down and tested rather than living in an expression halfway through
+/// `EngineController.reconcile`:
+///
+/// - a wallpaper with **no** value of its own follows the global setting
+/// - a wallpaper set to **zero** never freezes, and must NOT fall back to the
+///   global setting. "Never pause" is a decision, not an absence
+/// - a global setting of zero or nil means nothing freezes on its own
+///
+/// The difference between "no value" and "zero" is the whole feature: get it
+/// wrong and a wallpaper the user explicitly asked to keep playing starts
+/// freezing the moment they set a global default, which is the opposite of
+/// what they asked for and is invisible until they notice it standing still.
+public enum PauseAfter {
+    /// Seconds to play before freezing, or nil for "keep playing".
+    ///
+    /// - Parameters:
+    ///   - wallpaper: the wallpaper's own override. Nil means it has none.
+    ///   - global: the app-wide setting.
+    public static func resolve(wallpaper: Int?, global: Int?) -> Int? {
+        normalise(wallpaper ?? global)
+    }
+
+    /// Anything at or below zero means "never freeze". The engine only ever
+    /// wants a positive duration or nothing, so collapse the rest here instead
+    /// of leaving every caller to remember it.
+    public static func normalise(_ seconds: Int?) -> Int? {
+        guard let seconds, seconds > 0 else { return nil }
+        return seconds
+    }
+}

--- a/Muro/Tests/MuroKitTests/PauseAfterTests.swift
+++ b/Muro/Tests/MuroKitTests/PauseAfterTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import MuroKit
+
+/// Issue #3, "Pause after x sec". The feature shipped untested, and the one
+/// rule inside it is exactly the kind that breaks quietly.
+final class PauseAfterTests: XCTestCase {
+
+    // MARK: The global setting
+
+    func testNoSettingAnywhereMeansKeepPlaying() {
+        XCTAssertNil(PauseAfter.resolve(wallpaper: nil, global: nil))
+    }
+
+    func testTheGlobalSettingAppliesToAWallpaperWithoutOneOfItsOwn() {
+        XCTAssertEqual(PauseAfter.resolve(wallpaper: nil, global: 30), 30)
+    }
+
+    func testAGlobalSettingOfZeroIsOff() {
+        XCTAssertNil(PauseAfter.resolve(wallpaper: nil, global: 0))
+    }
+
+    // MARK: The per-wallpaper override
+
+    func testAWallpaperOverridesTheGlobalSetting() {
+        XCTAssertEqual(PauseAfter.resolve(wallpaper: 10, global: 300), 10)
+        XCTAssertEqual(PauseAfter.resolve(wallpaper: 3600, global: 10), 3600)
+    }
+
+    func testAWallpaperCanOptOutWhileTheSettingStillAppliesElsewhere() {
+        // The trap. Zero is "never pause", a decision the user made in the
+        // wallpaper's own menu. It must not read as "no opinion" and fall
+        // through to the global setting, or the one wallpaper someone asked
+        // to keep playing is the one that freezes.
+        XCTAssertNil(PauseAfter.resolve(wallpaper: 0, global: 30))
+        XCTAssertNil(PauseAfter.resolve(wallpaper: 0, global: 3600))
+    }
+
+    func testAWallpaperCanPauseWhileTheGlobalSettingIsOff() {
+        XCTAssertEqual(PauseAfter.resolve(wallpaper: 15, global: 0), 15)
+        XCTAssertEqual(PauseAfter.resolve(wallpaper: 15, global: nil), 15)
+    }
+
+    // MARK: Normalising
+
+    func testNegativesAndZeroCollapseToKeepPlaying() {
+        XCTAssertNil(PauseAfter.normalise(nil))
+        XCTAssertNil(PauseAfter.normalise(0))
+        XCTAssertNil(PauseAfter.normalise(-1))
+        XCTAssertNil(PauseAfter.normalise(Int.min))
+    }
+
+    func testAPositiveDurationSurvivesUntouched() {
+        for seconds in [1, 10, 30, 60, 120, 300, 900, 3600, 86_400] {
+            XCTAssertEqual(PauseAfter.normalise(seconds), seconds)
+        }
+    }
+
+    /// A negative value should never reach the engine, and if one ever does it
+    /// must not arm a timer with a negative interval.
+    func testANegativeOverrideDoesNotBecomeATimer() {
+        XCTAssertNil(PauseAfter.resolve(wallpaper: -5, global: 30))
+        XCTAssertNil(PauseAfter.resolve(wallpaper: nil, global: -5))
+    }
+
+    // MARK: The choices the Settings menu offers
+
+    func testEverySettingsChoiceResolvesToItself() {
+        for seconds in [10, 30, 60, 120, 300, 900, 3600] {
+            XCTAssertEqual(PauseAfter.resolve(wallpaper: nil, global: seconds), seconds)
+        }
+        XCTAssertNil(PauseAfter.resolve(wallpaper: nil, global: 0))  // "Off"
+    }
+}


### PR DESCRIPTION
Closes #3.

@deimosfr asked for a wallpaper that keeps moving for a few seconds after it changes or after an unlock, then holds still, on the desktop only.

That shipped in Muro 3.0 as **Pause After**: a global setting in Settings under PLAYBACK, plus a per wallpaper override in the preview pill bar. It only ever applies to Muro's own desktop window, so the lock screen is untouched, which is what was asked for.

What this PR adds is the part that was missing. The rule deciding the duration lived in an expression halfway through `EngineController.reconcile` and had no tests at all, and it has one trap in it:

- a wallpaper with **no** value of its own follows the global setting
- a wallpaper set to **zero** never pauses, and must **not** fall back to the global setting
- a global setting of zero means nothing pauses on its own

"Never pause" is a decision, not an absence. If those two ever collapse into each other, the one wallpaper someone explicitly asked to keep playing becomes the one that freezes, the moment they set a global default, and nothing tells them.

`PauseAfter` now owns the rule. `EngineController` and `WallpaperWindowController` both go through it, and ten tests hold it in place, including the zero case and negative durations that must never arm a timer.

No behaviour changes.
