### PR TITLE
Say when the network is why Explore is empty

### DIFF
--- a/Muro/Sources/MuroApp/ExploreView.swift
+++ b/Muro/Sources/MuroApp/ExploreView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MuroKit
 
 /// Explore, rebuilt in the 3.0 language (2026-08-24).
 ///
@@ -74,7 +75,10 @@ struct ExploreView: View {
                             if filtered.isEmpty {
                                 emptyState
                             } else {
-                                grid
+                                VStack(spacing: 22) {
+                                    catalogNotice
+                                    grid
+                                }
                             }
                         }
                         .padding(.horizontal, 40)
@@ -213,14 +217,64 @@ struct ExploreView: View {
         }
     }
 
-    private var emptyState: some View {
+    // MARK: - Empty states
+
+    /// The network got in the way rather than the filters, and there is
+    /// genuinely nothing to show. Someone with downloads still has a grid, and
+    /// gets `catalogNotice` above it instead of this.
+    private var connectionProblem: CatalogError? {
+        store.catalog.isEmpty ? store.catalogError : nil
+    }
+
+    /// Three different reasons a page can be empty, and each one deserves its
+    /// own answer. Saying "Nothing matches that" to someone whose connection
+    /// is blocked sends them to fiddle with filters that were never the
+    /// problem, which is what a user reported.
+    @ViewBuilder private var emptyState: some View {
+        if !store.catalogLoaded, store.catalog.isEmpty {
+            loadingState
+        } else if let problem = connectionProblem {
+            connectionState(problem)
+        } else {
+            noMatchesState
+        }
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: 14) {
+            ProgressView()
+                .controlSize(.large)
+                .tint(Color.muroAccent)
+            Text("Loading wallpapers…")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color.muroSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 84)
+    }
+
+    private func connectionState(_ problem: CatalogError) -> some View {
         VStack(spacing: 12) {
-            Image(systemName: "sparkle.magnifyingglass")
-                .font(.system(size: 22, weight: .medium))
-                .foregroundStyle(Color.muroAccent)
-                .frame(width: 54, height: 54)
-                .background(Circle().fill(.glassSheen(0.14, 0.05)))
-                .overlay(Circle().strokeBorder(Color.white.opacity(0.16), lineWidth: 1))
+            emptyIcon(symbol(for: problem))
+            Text(problem.title)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+            Text(problem.detail)
+                .font(.system(size: 12.5))
+                .foregroundStyle(Color.muroSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 380)
+            retryButton
+                .padding(.top, 6)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 70)
+    }
+
+    private var noMatchesState: some View {
+        VStack(spacing: 12) {
+            emptyIcon("sparkle.magnifyingglass")
             Text("Nothing matches that")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(.white)
@@ -235,6 +289,83 @@ struct ExploreView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 70)
+    }
+
+    /// The catalog is missing but the user's own downloads still fill the
+    /// grid. Without this the page looks complete and nothing says that most
+    /// of Explore is absent.
+    @ViewBuilder private var catalogNotice: some View {
+        if let problem = connectionProblem {
+            HStack(spacing: 13) {
+                Image(systemName: symbol(for: problem))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.muroAccent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(problem.title)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(.white)
+                    Text("Only the wallpapers you have already downloaded are showing.")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Color.muroSecondary)
+                }
+                Spacer(minLength: 12)
+                retryButton
+            }
+            .padding(.leading, 18)
+            .padding(.trailing, 14)
+            .padding(.vertical, 13)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(.glassSheen(0.11, 0.04))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.13), lineWidth: 1)
+            )
+        }
+    }
+
+    private var retryButton: some View {
+        Button {
+            store.retryCatalog()
+        } label: {
+            HStack(spacing: 7) {
+                if store.catalogRefreshing {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(Color.muroAccent)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                Text(store.catalogRefreshing ? "Checking…" : "Try Again")
+                    .font(.system(size: 12.5, weight: .semibold))
+            }
+            .foregroundStyle(Color.muroAccent)
+            .padding(.horizontal, 18)
+            .frame(height: 40)
+            .background(Capsule().fill(Color.muroAccent.opacity(0.13)))
+            .overlay(Capsule().strokeBorder(Color.muroAccent.opacity(0.28), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .disabled(store.catalogRefreshing)
+    }
+
+    private func emptyIcon(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 22, weight: .medium))
+            .foregroundStyle(Color.muroAccent)
+            .frame(width: 54, height: 54)
+            .background(Circle().fill(.glassSheen(0.14, 0.05)))
+            .overlay(Circle().strokeBorder(Color.white.opacity(0.16), lineWidth: 1))
+    }
+
+    private func symbol(for problem: CatalogError) -> String {
+        switch problem {
+        case .unreachable: return "wifi.slash"
+        case .server: return "exclamationmark.icloud"
+        case .unreadable: return "exclamationmark.shield"
+        }
     }
 }
 

--- a/Muro/Sources/MuroApp/Store.swift
+++ b/Muro/Sources/MuroApp/Store.swift
@@ -138,6 +138,21 @@ final class AppStore: ObservableObject {
     /// user has to be told that rather than left with an app that quietly
     /// ignores them.
     @Published var libraryUnreadable = false
+    /// Why the last catalog fetch failed, or nil when it worked.
+    ///
+    /// Every failure used to be swallowed by a `try?` and Explore answered all
+    /// of them with "Nothing matches that", so a blocked connection was
+    /// indistinguishable from filters set too narrow. A user reported it as
+    /// "how can I view the explore section", which is exactly the confusion
+    /// that wording creates.
+    @Published var catalogError: CatalogError?
+    /// False until the first fetch has finished, either way. Explore must not
+    /// accuse anyone of over-filtering an empty page while the first fetch is
+    /// still in the air.
+    @Published private(set) var catalogLoaded = false
+    /// A retry the user asked for is in flight, so the button can say so
+    /// instead of looking dead.
+    @Published private(set) var catalogRefreshing = false
 
     private var watcher: DispatchSourceFileSystemObject?
     private let scheduler = AutomationScheduler()
@@ -507,13 +522,36 @@ final class AppStore: ObservableObject {
         set { defaults.set(newValue, forKey: "catalogURL"); Task { await refreshCatalog() } }
     }
 
+    /// Fetches the catalog and remembers what happened.
+    ///
+    /// It used to be a silent no-op on every failure, which is right for the
+    /// app still working offline and wrong for the user, who was left with an
+    /// empty Explore and no way to know the network was the reason. The last
+    /// good catalog still stays in memory, so one failed refresh never empties
+    /// an Explore that was working a moment ago.
     func refreshCatalog() async {
-        // Silent no-op on any failure — the repo may not exist yet and the
-        // app must work fully offline.
-        guard let url = URL(string: catalogURLString) else { return }
-        if let fetched = try? await RemoteCatalog.fetch(from: url) {
+        defer { catalogLoaded = true }
+        guard let url = URL(string: catalogURLString) else {
+            catalogError = .unreachable
+            return
+        }
+        do {
+            let fetched = try await RemoteCatalog.fetch(from: url)
             catalog = fetched.wallpapers
+            catalogError = nil
             noteCatalogArrivals()
+        } catch {
+            catalogError = CatalogError.classify(error)
+        }
+    }
+
+    /// The Try Again button in Explore.
+    func retryCatalog() {
+        guard !catalogRefreshing else { return }
+        Task {
+            catalogRefreshing = true
+            await refreshCatalog()
+            catalogRefreshing = false
         }
     }
 

--- a/Muro/Sources/MuroKit/RemoteCatalog.swift
+++ b/Muro/Sources/MuroKit/RemoteCatalog.swift
@@ -77,11 +77,106 @@ public struct RemoteCatalog: Codable {
     /// leaves only the CDN's own ~5 minute window, which we can't bypass
     /// (raw.githubusercontent.com keys its cache without the query string,
     /// so a cache-busting parameter does nothing).
+    ///
+    /// Throws a `CatalogError`, never a raw transport or decoding error. The
+    /// caller has to tell a blocked connection apart from a rate limited CDN
+    /// apart from a catalog it simply could not read, because those are three
+    /// different sentences to put in front of a person.
     public static func fetch(from url: URL) async throws -> RemoteCatalog {
         var request = URLRequest(url: url)
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.timeoutInterval = 20
-        let (data, _) = try await URLSession.shared.data(for: request)
-        return try makeDecoder().decode(RemoteCatalog.self, from: data)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw CatalogError.classify(error)
+        }
+
+        // The status used to be discarded, and that is the whole bug. Every
+        // error a static host returns arrives as a body: r2.dev answers a rate
+        // limit or a missing key with a 27 KB HTML page. Handing that to the
+        // decoder produced a decoding failure, which the app swallowed, so a
+        // throttled CDN and an empty catalog were the same thing to it.
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw CatalogError.server(status: http.statusCode)
+        }
+
+        do {
+            return try makeDecoder().decode(RemoteCatalog.self, from: data)
+        } catch {
+            throw CatalogError.unreadable
+        }
+    }
+}
+
+/// Why the catalog did not arrive, in the three shapes a person can act on.
+///
+/// Explore used to answer all of them with "Nothing matches that", which
+/// blames the user's filters for something they cannot see and cannot fix by
+/// changing a filter. A user reported exactly that: an empty Explore reads as
+/// a broken app rather than a blocked connection.
+public enum CatalogError: LocalizedError, Equatable {
+    /// Nothing reached the server at all: offline, a host that will not
+    /// resolve, a timeout, or a VPN, firewall or DNS filter in the way.
+    case unreachable
+    /// The server answered, and not with the catalog. 429 is the r2.dev rate
+    /// limit, 5xx is the CDN being unwell, 404 is a bucket that has moved.
+    case server(status: Int)
+    /// A 200 that was not the wallpaper list. A captive portal sign in page
+    /// and a filter's block page both arrive looking exactly like this.
+    case unreadable
+
+    /// The headline. Short enough to sit under an icon.
+    public var title: String {
+        switch self {
+        case .unreachable: return "Muro cannot reach the internet"
+        case .server: return "The wallpaper catalog is not answering"
+        case .unreadable: return "Something is blocking the wallpaper catalog"
+        }
+    }
+
+    /// What to do about it. Never blames the filters, always names the causes
+    /// people actually hit.
+    public var detail: String {
+        switch self {
+        case .unreachable:
+            return """
+            Check that you are online, then try again. A VPN, a firewall or a \
+            DNS filter can also stop Muro reaching its wallpapers.
+            """
+        case .server(let status):
+            return """
+            The server answered with an error (\(status)). This is usually \
+            temporary, so try again in a minute.
+            """
+        case .unreadable:
+            return """
+            Muro reached the catalog but what came back was not the wallpaper \
+            list. A VPN, a company network or a DNS filter can do this.
+            """
+        }
+    }
+
+    public var errorDescription: String? { "\(title). \(detail)" }
+
+    /// Everything that can go wrong on the way to a catalog, sorted into the
+    /// three cases. Anything unrecognised counts as unreachable, which is the
+    /// safe guess: it sends the user to look at their connection rather than
+    /// at a filter that was never the problem.
+    public static func classify(_ error: Error) -> CatalogError {
+        if let catalogError = error as? CatalogError { return catalogError }
+        if error is DecodingError { return .unreadable }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .badServerResponse, .cannotParseResponse, .zeroByteResource:
+                return .unreadable
+            default:
+                return .unreachable
+            }
+        }
+        return .unreachable
     }
 }

--- a/Muro/Tests/MuroKitTests/RemoteCatalogTests.swift
+++ b/Muro/Tests/MuroKitTests/RemoteCatalogTests.swift
@@ -87,4 +87,68 @@ final class RemoteCatalogTests: XCTestCase {
     func testMalformedJSONThrowsRatherThanCrashing() {
         XCTAssertThrowsError(try decode("{\"wallpapers\": \"not an array\"}"))
     }
+
+    // MARK: - Why the catalog did not arrive
+    //
+    // A user reported an empty Explore as "how can I view the explore
+    // section". The catalog was live and correct; his machine could not reach
+    // it, and the app had no way to say so because every failure was swallowed
+    // and answered with "Nothing matches that". These pin the three answers
+    // apart.
+
+    /// A static host answers a rate limit or a missing key with an HTML page,
+    /// so the body decodes as garbage. Classifying on the body alone is what
+    /// made a throttled CDN look like a badly filtered page, and it is why the
+    /// status code is checked before the decoder ever sees the bytes.
+    func testAnHTMLErrorPageIsNotMistakenForAnEmptyCatalog() {
+        let html = Data("<!doctype html><html><title>Not Found</title></html>".utf8)
+        XCTAssertThrowsError(
+            try RemoteCatalog.makeDecoder().decode(RemoteCatalog.self, from: html)
+        ) { error in
+            XCTAssertEqual(CatalogError.classify(error), .unreadable)
+        }
+    }
+
+    func testOfflineIsReportedAsUnreachable() {
+        XCTAssertEqual(
+            CatalogError.classify(URLError(.notConnectedToInternet)), .unreachable
+        )
+    }
+
+    /// A blocked or unresolvable host is the shape a DNS filter, a VPN or a
+    /// company network takes.
+    func testABlockedHostIsReportedAsUnreachable() {
+        for code in [URLError.cannotFindHost, .timedOut, .networkConnectionLost,
+                     .secureConnectionFailed, .cannotConnectToHost] {
+            XCTAssertEqual(CatalogError.classify(URLError(code)), .unreachable)
+        }
+    }
+
+    func testAServerErrorKeepsItsStatusCode() {
+        let rateLimited = CatalogError.server(status: 429)
+        XCTAssertEqual(CatalogError.classify(rateLimited), rateLimited)
+        XCTAssertTrue(rateLimited.detail.contains("429"))
+    }
+
+    /// Anything unrecognised has to land on unreachable: that sends someone to
+    /// look at their connection rather than at filters that were never the
+    /// problem.
+    func testAnUnknownErrorFallsBackToUnreachable() {
+        struct Odd: Error {}
+        XCTAssertEqual(CatalogError.classify(Odd()), .unreachable)
+    }
+
+    /// Every case has to be sayable out loud, and the project does not put
+    /// em-dashes in front of users.
+    func testEveryCaseHasCopyAPersonCanRead() {
+        for problem in [CatalogError.unreachable, .server(status: 503), .unreadable] {
+            XCTAssertFalse(problem.title.isEmpty)
+            XCTAssertFalse(problem.detail.isEmpty)
+            XCTAssertFalse(problem.title.contains("—"), "em-dash in \(problem)")
+            XCTAssertFalse(problem.detail.contains("—"), "em-dash in \(problem)")
+            // Never the old message, which blamed the filters for a network
+            // failure.
+            XCTAssertFalse(problem.detail.lowercased().contains("category"))
+        }
+    }
 }


### PR DESCRIPTION
Reported in #7, where Explore was empty and the app gave no reason for it.

The catalog was live and correct the whole time. R2 was checked first and cleared: `catalog.json` returned 200 with the right cache header, 30 rapid requests all returned 200 with no throttling, the live catalog decoded with the app own types into 127 wallpapers with no duplicate ids and every preview present, all 33 assets of the newest drop returned 200 / 200 / 206, and the host resolved on Cloudflare, Google, Quad9, OpenDNS and AdGuard. The problem was that his Mac could not reach it and Muro had no way to say so.

## What was wrong

Two bugs stacked on each other.

`RemoteCatalog.fetch` threw the HTTP response away and handed the body straight to the decoder. A static host answers a rate limit or a missing key with an HTML page, 27 KB of it in this case, so a blocked or throttled host arrived looking exactly like a catalog that would not parse.

Then `refreshCatalog` swallowed all of it with a `try?`, and Explore answered every empty page with "Nothing matches that. Try another category, or widen the resolution and frame rate." That sends someone whose connection is blocked off to adjust filters that were never the problem, which is why this arrived as a question about how to use Explore rather than as a bug report.

## What changed

The status code is checked now, before the decoder sees anything, and failures are sorted into the three cases a person can act on: nothing reached the server, the server answered with an error, or something came back that was not the wallpaper list. Each one says what it is and names the causes people actually hit, a VPN, a firewall, a DNS filter or a company network.

Explore has four states rather than one:

- it says it is loading while the first fetch is still in the air, instead of claiming nothing matches
- it shows the connection problem, with a Try Again button, when there is nothing to show
- it keeps the old message for a page that really is filtered too narrowly
- it puts a small notice above the grid when the user own downloads still fill it, because otherwise the page looks complete while most of Explore is missing

The last good catalog stays in memory either way, so one failed refresh never empties an Explore that was working a moment ago.

## Verification

Six new tests cover the sorting, including the HTML error page that started this, and that no case carries an em-dash or blames a category. 112 tests pass, up from 106.

Checked against live endpoints as well, not only in tests:

| Case | Result |
|---|---|
| Real catalog | decodes, 127 wallpapers |
| 404 with an HTML body | server error, carrying its status code |
| Host that does not resolve | no internet |
| A 200 that is not the catalog | blocked |

No raw transport or decoding error leaks out of `fetch` any more.

## Not in this change

No disk cache for the catalog. That is the bigger fix and it would make this class of failure invisible rather than merely legible, since a throttle or an offline launch would show the catalog the user already had. It is the next thing worth doing.

Issue #7 stays open on purpose, and merging this must not shut it. The reporter has been asked for his network and region and the output of a `curl -I` against the catalog URL, and that answer still decides whether this was his own connection or the CDN rate limiting us.
