### PR TITLE
Build Muro for Intel Macs as well as Apple Silicon

### DIFF
--- a/Muro/MuroWallpaperExtension.xcodeproj/project.pbxproj
+++ b/Muro/MuroWallpaperExtension.xcodeproj/project.pbxproj
@@ -139,7 +139,7 @@
 		A1000000000000000000000D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = arm64;
+				ARCHS = "arm64 x86_64";
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 6;
@@ -169,7 +169,7 @@
 		A1000000000000000000000E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = arm64;
+				ARCHS = "arm64 x86_64";
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 6;

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -14,8 +14,13 @@ BUILD="6"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"
 
-echo "==> swift build -c release"
-swift build -c release --package-path "$DIR"
+# Universal, so every Mac that can run macOS 14 gets a native slice rather
+# than only Apple Silicon. Both slices are the same source compiled twice,
+# which is why nothing else in the project has to know about Intel: every
+# later change reaches both without a second thought. The wallpaper
+# extension carries the same two architectures, set in its Xcode project.
+echo "==> swift build -c release (universal: arm64 + x86_64)"
+swift build -c release --package-path "$DIR" --arch arm64 --arch x86_64
 
 echo "==> assembling $APP"
 rm -rf "$DIR/dist"


### PR DESCRIPTION
The README promised Intel support and the build was arm64 only, so anyone on an Intel Mac downloaded a DMG that could not run.

Two lines fix it. The package build asks for both architectures, and the wallpaper extension's Xcode project stops declaring arm64 alone. No source changed, because there is no architecture specific code anywhere, so both slices are the same source compiled twice.

Both the app and the extension come out carrying x86_64 and arm64. The app's slices keep a macOS 14 minimum, so they run on every Intel Mac that can run Sonoma, and the extension keeps 26.0 because the lock screen needs it there.

Raised in #9. Leaving that issue open, since this has not yet been confirmed on a real Intel Mac.
