### PR TITLE
Keep Muro out of the Dock, and answer when the Dock is clicked

### DIFF
--- a/Muro/Sources/MuroApp/Components.swift
+++ b/Muro/Sources/MuroApp/Components.swift
@@ -345,16 +345,75 @@ struct ImportButton: View {
     }
 }
 
+/// Muro's two `Window` scenes, by the titles SwiftUI gives them.
+enum MuroWindow {
+    static let gallery = "Muro"
+    static let settings = "Muro Settings"
+}
+
+@MainActor
+func window(titled title: String) -> NSWindow? {
+    NSApp.windows.first { $0.title == title }
+}
+
+/// The gallery window itself. `Window("Muro", id: "main")` is a SwiftUI scene,
+/// and closing it only orders it out, so it can always be brought back.
+@MainActor
+var mainWindow: NSWindow? { window(titled: MuroWindow.gallery) }
+
+/// Bring the gallery forward. Three places needed the same three lines, and
+/// the app delegate now needs them too when the Dock icon or Spotlight asks
+/// for a window that is only ordered out.
+@MainActor
+func showMainWindow() {
+    NSApp.activate(ignoringOtherApps: true)
+    mainWindow?.makeKeyAndOrderFront(nil)
+}
+
+/// Make a window's yellow button put it away rather than minimise it.
+///
+/// A minimised window is a different thing from an app icon, and the Dock
+/// treats it that way: `.accessory` hides the icon, it does not hide a
+/// minimised window. So with "Show Dock icon" switched off, minimising left a
+/// lone Muro thumbnail parked beside the Trash with no app icon to belong to,
+/// and nothing obvious to do about it.
+///
+/// Muro lives in the menu bar. Putting a window away should put it away, and
+/// the menu bar is how the gallery comes back, exactly like the red button.
+/// The button is left enabled and yellow rather than removing
+/// `.miniaturizable`, because a dead greyed-out button reads as broken.
+///
+/// **Every window scene has to ask for this.** Doing only the gallery left
+/// Settings minimising into the Dock exactly as before, which is how the first
+/// version of this shipped.
+@MainActor
+func makeMinimiseHideTheWindow(titled title: String) {
+    guard let button = window(titled: title)?.standardWindowButton(.miniaturizeButton)
+    else { return }
+    button.target = WindowButtonTarget.shared
+    button.action = #selector(WindowButtonTarget.hideWindow(_:))
+}
+
+/// Owns the retargeted button action. A plain function cannot be a `#selector`
+/// target, and a button does not retain its target, so this has to outlive it.
+@MainActor
+final class WindowButtonTarget: NSObject {
+    static let shared = WindowButtonTarget()
+
+    /// The sender is the button, so it knows its own window. One target can
+    /// serve every window rather than one per scene.
+    @objc func hideWindow(_ sender: Any?) {
+        (sender as? NSView)?.window?.orderOut(nil)
+    }
+}
+
 /// Bring the gallery forward and open What's New on it. The menu bar and
 /// Settings both point their "update available" line here, so there is one
 /// place in the app where an update is read about and downloaded.
 @MainActor
 func openWhatsNew(_ store: AppStore) {
     StatusBarController.shared?.closePanel()
-    NSApp.activate(ignoringOtherApps: true)
-    for window in NSApp.windows where window.title == "Muro" {
-        window.makeKeyAndOrderFront(nil)
-    }
+    showMainWindow()
     store.whatsNewOpen = true
     store.markUpdateSeen()
 }

--- a/Muro/Sources/MuroApp/MenuBarView.swift
+++ b/Muro/Sources/MuroApp/MenuBarView.swift
@@ -297,10 +297,7 @@ struct MenuBarView: View {
         VStack(spacing: 2) {
             menuRow("Open Muro") {
                 StatusBarController.shared?.closePanel()
-                NSApp.activate(ignoringOtherApps: true)
-                for window in NSApp.windows where window.title == "Muro" {
-                    window.makeKeyAndOrderFront(nil)
-                }
+                showMainWindow()
             }
             menuRow("Settings") {
                 StatusBarController.shared?.closePanel()

--- a/Muro/Sources/MuroApp/MuroApp.swift
+++ b/Muro/Sources/MuroApp/MuroApp.swift
@@ -4,20 +4,100 @@ import MuroKit
 
 /// The Muro app: gallery window + settings + menu bar, with the wallpaper
 /// engine embedded (one process, one config, instant hot-reload).
+@MainActor
 final class MuroAppDelegate: NSObject, NSApplicationDelegate {
     let engine = EngineController()
     private var statusBar: StatusBarController?
 
+    /// True when macOS started Muro at login rather than a person opening it.
+    private var startedAtLogin = false
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        // Read here and nowhere later. The launch Apple event only sits on the
+        // queue while the app is starting, so by the time anything else could
+        // ask, the answer is gone.
+        startedAtLogin = Self.launchedAsLoginItem()
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
-        let showDock = UserDefaults.standard.object(forKey: "showDockIcon") as? Bool ?? true
-        NSApp.setActivationPolicy(showDock ? .regular : .accessory)
+        Self.applyActivationPolicy()
         engine.start()
         statusBar = StatusBarController(store: AppStore.shared)
-        NSApp.activate(ignoringOtherApps: true)
+
+        // Starting at login is the Mac booting, not a person asking to see the
+        // gallery. Muro used to throw its full window on screen every single
+        // boot, which had to be closed by hand every single time. It starts in
+        // the menu bar now and waits to be asked.
+        if startedAtLogin {
+            hideMainWindow()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    /// Opening an app that is already running, from Spotlight, the Dock or
+    /// Finder. Without this the click did nothing at all: the window is only
+    /// ordered out, not closed, so nothing reopened it and the only way back
+    /// in was the menu bar.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        Self.applyActivationPolicy()
+        showMainWindow()
+        return true
+    }
+
+    /// Re-assert the Dock setting whenever Muro comes to the front.
+    ///
+    /// Launching an already-running Muro from Spotlight left an icon in the
+    /// Dock even with "Show Dock icon" switched off, and it stayed there. The
+    /// only cure anyone found was opening Settings and flicking that toggle on
+    /// and off, which is nothing more than calling `setActivationPolicy`
+    /// again. So call it again here, where it costs nothing and no one has to
+    /// know the trick.
+    func applicationDidBecomeActive(_ notification: Notification) {
+        Self.applyActivationPolicy()
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false   // keep playing wallpapers from the menu bar
+    }
+
+    // MARK: - Helpers
+
+    /// The Dock icon setting, applied. Idempotent, so it is safe to call on
+    /// every activation.
+    static func applyActivationPolicy() {
+        let showDock = UserDefaults.standard.object(forKey: "showDockIcon") as? Bool ?? true
+        let wanted: NSApplication.ActivationPolicy = showDock ? .regular : .accessory
+        guard NSApp.activationPolicy() != wanted else { return }
+        NSApp.setActivationPolicy(wanted)
+    }
+
+    /// Did macOS start us as a login item?
+    ///
+    /// There is no flag on `NSApplication` for this. The launch Apple event
+    /// carries it: an `oapp` event with a `prdt` parameter of `lgit`. This is
+    /// the documented way and it is what `SMAppService` login starts send.
+    private static func launchedAsLoginItem() -> Bool {
+        guard let event = NSAppleEventManager.shared().currentAppleEvent,
+              event.eventID == kAEOpenApplication
+        else { return false }
+        return event.paramDescriptor(forKeyword: keyAEPropData)?
+            .enumCodeValue == keyAELaunchedAsLogInItem
+    }
+
+    /// Put the gallery away without closing it.
+    ///
+    /// Run more than once on purpose. SwiftUI creates the `Window` scene's
+    /// `NSWindow` around launch rather than at a moment we control, so a
+    /// single pass here can happen before the window exists and miss it. The
+    /// later passes are cheap and catch that case.
+    private func hideMainWindow() {
+        mainWindow?.orderOut(nil)
+        Task { @MainActor in
+            mainWindow?.orderOut(nil)
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            mainWindow?.orderOut(nil)
+        }
     }
 }
 
@@ -28,22 +108,28 @@ struct MuroApp: App {
     @Environment(\.openWindow) private var openWindow
 
     var body: some Scene {
-        Window("Muro", id: "main") {
+        Window(MuroWindow.gallery, id: "main") {
             RootView()
                 .environmentObject(store)
                 .frame(minWidth: 1180, minHeight: 760)
                 .preferredColorScheme(.dark)
                 .onAppear {
                     SettingsWindowOpener.shared.open = { openWindow(id: "settings") }
+                    // Here rather than in the delegate: the window is what is
+                    // being reconfigured, and by the time its content appears
+                    // it definitely exists. Re-applied on every appearance, so
+                    // it survives the window being rebuilt.
+                    makeMinimiseHideTheWindow(titled: MuroWindow.gallery)
                 }
         }
         .defaultSize(width: 1440, height: 920)
         .windowStyle(.hiddenTitleBar)
 
-        Window("Muro Settings", id: "settings") {
+        Window(MuroWindow.settings, id: "settings") {
             SettingsView()
                 .environmentObject(store)
                 .preferredColorScheme(.dark)
+                .onAppear { makeMinimiseHideTheWindow(titled: MuroWindow.settings) }
         }
         .windowResizability(.contentSize)
         .windowStyle(.hiddenTitleBar)

--- a/Muro/Sources/MuroApp/SettingsView.swift
+++ b/Muro/Sources/MuroApp/SettingsView.swift
@@ -226,7 +226,7 @@ struct SettingsView: View {
             .onReceive(NotificationCenter.default.publisher(
                 for: NSWindow.willCloseNotification
             )) { note in
-                if (note.object as? NSWindow)?.title == "Muro Settings" {
+                if (note.object as? NSWindow)?.title == MuroWindow.settings {
                     scrollToTopOnNextOpen = true
                 }
             }
@@ -234,7 +234,7 @@ struct SettingsView: View {
                 for: NSWindow.didBecomeKeyNotification
             )) { note in
                 guard scrollToTopOnNextOpen,
-                      (note.object as? NSWindow)?.title == "Muro Settings" else { return }
+                      (note.object as? NSWindow)?.title == MuroWindow.settings else { return }
                 scrollToTopOnNextOpen = false
                 proxy.scrollTo("settings-top", anchor: .top)
             }


### PR DESCRIPTION
Muro threw its whole window on screen every time the Mac booted. With launch at login on, which is the point of a wallpaper app, that meant closing the same window every single morning, while the setting said "starts quietly in the background".

Starting at login is the Mac coming up, not a person asking to see the gallery. Muro reads which of the two it was, from the launch Apple event, and on a login start it comes up in the menu bar with no window. Launching it yourself still opens the gallery, because an app that shows nothing when you double click it looks broken.

Two neighbours of the same problem went with it. Opening an already running Muro from Spotlight or the Dock did nothing at all, since the window is ordered out rather than closed and nothing was left to reopen it. And minimising parked a lone window in the Dock with no app icon beside it, because accessory mode hides the icon but not a minimised window.

Reported in #13.
