### PR TITLE
Put the lock screen wallpaper where macOS actually reads it

### DIFF
--- a/Muro/Sources/MuroApp/LockScreenService.swift
+++ b/Muro/Sources/MuroApp/LockScreenService.swift
@@ -42,6 +42,14 @@ enum LockScreenServiceError: LocalizedError {
 /// away a selection that was usually about to settle a second later.
 enum LockScreenApplyOutcome {
     case applied
+    /// Written, held by the stores, but macOS has not come to collect it yet.
+    ///
+    /// Deliberately separate from `.needsSystemSettings`, which puts a modal
+    /// alert in front of the user. This one says nothing on screen and only
+    /// reaches the diagnostics log. An apply that macOS picks up a moment late
+    /// is common; telling somebody their wallpaper failed when it is about to
+    /// work would be worse than the silence it replaced.
+    case pendingAcknowledgement
     case needsSystemSettings
 }
 
@@ -198,6 +206,56 @@ final class LockScreenService {
         }
     }
 
+    /// The extension's side of the handshake. Mirrors the type it writes.
+    private struct AcquireReceipt: Codable {
+        var id: String
+        var at: Date
+        var ok: Bool
+        var preview: Bool
+        var detail: String
+    }
+
+    private static var acquireReceiptURL: URL {
+        extensionDocumentsURL.appendingPathComponent("acquire-receipt.json")
+    }
+
+    private static func latestReceipt() -> AcquireReceipt? {
+        guard let data = try? Data(contentsOf: acquireReceiptURL) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(AcquireReceipt.self, from: data)
+    }
+
+    /// Waits for macOS to actually come and collect the wallpaper.
+    ///
+    /// This replaces re-reading the property list Muro had just written, which
+    /// could only ever fail if WallpaperAgent deleted the line within a few
+    /// seconds. Everything else, macOS ignoring the choice included, read as
+    /// success. A receipt is written by the extension when macOS calls
+    /// `acquire`, so it cannot be produced by Muro talking to itself.
+    ///
+    /// A preview acquire counts. It is still macOS accepting the provider and
+    /// finding the staged file, and refusing it would invent failures on any
+    /// Mac that previews before it commits.
+    private static func awaitAcknowledgement(
+        wallpaperID: String,
+        since: Date,
+        timeout: TimeInterval
+    ) async -> Bool {
+        func matches() -> Bool {
+            guard let receipt = latestReceipt() else { return false }
+            return receipt.ok
+                && receipt.id == wallpaperID
+                && receipt.at >= since.addingTimeInterval(-1)
+        }
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if matches() { return true }
+            try? await Task.sleep(nanoseconds: 250_000_000)
+        }
+        return matches()
+    }
+
     @discardableResult
     func apply(
         entry: WallpaperEntry,
@@ -234,8 +292,10 @@ final class LockScreenService {
                 // watch for the selection to appear; if the agent clobbered it,
                 // write again. Three passes, about ten seconds in the worst
                 // case, and almost always settled on the first.
-                var settled = false
-                for attempt in 1...3 {
+                let applyStart = Date()
+                var acknowledged = false
+                var storeHolds = false
+                for _ in 1...3 {
                     try await Self.updateWallpaperStores(
                         wallpaperID: entry.id,
                         videoURL: Self.stagedVideoURL(id: entry.id),
@@ -244,16 +304,26 @@ final class LockScreenService {
                     )
                     Self.notifyLibraryChanged()
                     Self.restartWallpaperAgent()
-                    if await Self.awaitSelection(timeout: attempt == 1 ? 4 : 3) {
-                        settled = true
+                    if await Self.awaitAcknowledgement(
+                        wallpaperID: entry.id, since: applyStart, timeout: 3
+                    ) {
+                        acknowledged = true
+                        storeHolds = true
                         break
                     }
+                    // No receipt. If the stores still hold the choice then
+                    // macOS simply has not come looking, and writing it a
+                    // fourth time will not make it. Only a choice the agent
+                    // overwrote is worth another pass.
+                    storeHolds = Self.wallpaperStoresHaveSelection()
+                    if storeHolds { break }
                 }
 
                 try Self.saveState(nextState, root: root)
                 try Self.pruneStagedLibrary(
                     keeping: Set(nextState.selections.values).subtracting([Self.removedSelection])
                 )
+                let settled = acknowledged || storeHolds
                 // The wallpaper this one replaced has just lost its staged
                 // file, so every record still naming it is now dead. Sweeping
                 // here is what stops the stores growing a layer per wallpaper.
@@ -262,19 +332,20 @@ final class LockScreenService {
                 if (try? Self.purgeDeadMuroSurfaces(root: root)) == true {
                     Self.restartWallpaperAgent()
                 }
-                if !settled {
-                    // Everything Muro owns is written and the extension is
-                    // registered. Only macOS has not acknowledged it. Keep the
-                    // lot and tell the user the one step that finishes it.
-                    Self.recordDiagnostics(
-                        root: root,
-                        wallpaperID: entry.id,
-                        targetKey: targetKey,
-                        registered: true,
-                        settled: false
-                    )
-                }
-                return settled ? .applied : .needsSystemSettings
+                // Recorded every time now, not only on failure. An apply that
+                // reports success and quietly does nothing is exactly the case
+                // that used to leave no trace at all, which is what made the
+                // first report of it unanswerable.
+                Self.recordDiagnostics(
+                    root: root,
+                    wallpaperID: entry.id,
+                    targetKey: targetKey,
+                    registered: true,
+                    settled: settled,
+                    acknowledged: acknowledged
+                )
+                if !settled { return .needsSystemSettings }
+                return acknowledged ? .applied : .pendingAcknowledgement
             } catch {
                 // Only a real failure rolls back: the extension would not
                 // register, or a store write threw. A slow agent no longer
@@ -358,6 +429,7 @@ final class LockScreenService {
             Self.unregisterExtension(at: extensionURL)
             try? FileManager.default.removeItem(at: Self.extensionDocumentsURL)
             try? FileManager.default.removeItem(at: Self.stateURL(root: root))
+            try? FileManager.default.removeItem(at: Self.acquireReceiptURL)
             try? FileManager.default.removeItem(at: Self.backupDirectoryURL(root: root))
             try? FileManager.default.removeItem(at: Self.legacyBackupURL(root: root))
         }.value
@@ -463,16 +535,6 @@ final class LockScreenService {
         wallpaperStoreURLs.contains {
             containsMuroSurface(named: "Desktop", in: loadWallpaperStore(at: $0))
         }
-    }
-
-    /// Watch for the selection instead of guessing how long the agent takes.
-    private static func awaitSelection(timeout: TimeInterval) async -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if wallpaperStoresHaveSelection() { return true }
-            try? await Task.sleep(nanoseconds: 250_000_000)
-        }
-        return wallpaperStoresHaveSelection()
     }
 
     private static func containsMuroSurface(named name: String, in value: Any?) -> Bool {
@@ -1022,6 +1084,7 @@ final class LockScreenService {
         targetKey: String,
         registered: Bool,
         settled: Bool,
+        acknowledged: Bool = false,
         error: Error? = nil
     ) {
         let version = ProcessInfo.processInfo.operatingSystemVersionString
@@ -1036,6 +1099,13 @@ final class LockScreenService {
             "target=\(targetKey)",
             "registered=\(registered)",
             "settled=\(settled)",
+            // The honest half. `settled` only says the stores kept what Muro
+            // wrote; `acknowledged` says macOS came and collected it.
+            "acknowledged=\(acknowledged)",
+            latestReceipt().map {
+                "receipt=\($0.detail)/\($0.ok ? "ok" : "failed")"
+                    + ($0.preview ? "/preview" : "")
+            } ?? "receipt=none",
             stores,
             error.map { "error=\($0.localizedDescription)" } ?? "",
         ].filter { !$0.isEmpty }.joined(separator: " | ")

--- a/Muro/Sources/MuroApp/LockScreenService.swift
+++ b/Muro/Sources/MuroApp/LockScreenService.swift
@@ -54,18 +54,16 @@ enum LockScreenApplyOutcome {
 }
 
 /// Owns the Apple-managed half of Muro playback. It stages only wallpapers
-/// selected for the lock screen and writes them into the Apple `Desktop`
-/// surface of both wallpaper stores (`Index.plist` and macOS 26+'s
-/// authoritative `Index2.plist`).
+/// selected for the lock screen and writes them into both wallpaper stores
+/// (`Index.plist` and macOS 26+'s authoritative `Index2.plist`).
 ///
-/// Why `Desktop` and not `Idle`: on macOS 26/27 the lock screen renders the
-/// **Desktop** wallpaper surface — there is no separate lock-only surface, and
-/// `Idle` is the screen *saver*. Writing `Idle` (the old approach) made the
-/// System Settings tile appear but never changed the lock screen, so the very
-/// first wallpaper that reached `Desktop` (via a manual System Settings click)
-/// stayed frozen there. Muro's own borderless window still owns the *visible*
-/// desktop, and the extension keeps `alwaysPauseDesktop` so it is a paused
-/// still (≈0% CPU) on the desktop and only plays while locked.
+/// The lock screen has no surface of its own, so it renders whatever fills the
+/// desktop role. Which key that is depends on the node, and `AppleWallpaperStore`
+/// owns that rule: `Desktop` when the desktop and lock screen are set apart,
+/// `Linked` when they share one wallpaper. `Idle` is the screen *saver* and is
+/// never ours. Muro's own borderless window still owns the *visible* desktop,
+/// and the extension keeps `alwaysPauseDesktop`, so it is a paused still on the
+/// desktop and only plays while locked.
 ///
 /// It restores every record it owns before deleting staged files.
 final class LockScreenService {
@@ -533,23 +531,12 @@ final class LockScreenService {
     /// meant a correct apply reported itself as a failure.
     private static func wallpaperStoresHaveSelection() -> Bool {
         wallpaperStoreURLs.contains {
-            containsMuroSurface(named: "Desktop", in: loadWallpaperStore(at: $0))
+            AppleWallpaperStore.containsProvider(
+                extensionBundleID, in: loadWallpaperStore(at: $0)
+            )
         }
     }
 
-    private static func containsMuroSurface(named name: String, in value: Any?) -> Bool {
-        guard let value else { return false }
-        if let dictionary = value as? [String: Any] {
-            if let surface = dictionary[name] as? [String: Any], isMuroSurface(surface) {
-                return true
-            }
-            return dictionary.values.contains { containsMuroSurface(named: name, in: $0) }
-        }
-        if let array = value as? [Any] {
-            return array.contains { containsMuroSurface(named: name, in: $0) }
-        }
-        return false
-    }
 
     private static func saveState(_ state: SelectionState, root: URL) throws {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -702,36 +689,41 @@ final class LockScreenService {
 
             let data = existed ? try Data(contentsOf: storeURL) : seedData
             var store = try PropertyListSerialization.propertyList(from: data, format: nil)
-            var changed = 0
-            // The lock screen renders the Desktop surface on macOS 26/27, so
-            // that is what we replace. Muro's own window keeps the visible
-            // desktop; the extension stays paused there (alwaysPauseDesktop).
-            mutateSurfaces(named: "Desktop", in: &store, path: []) { surfacePath, surface in
-                guard targetKey == "all" || surfacePath.contains(targetKey) else { return surface }
-                changed += 1
-                return surfaceApplying(choice: choice, to: surface)
-            }
+            // Each node says which surface it keeps its wallpaper under, and
+            // that is the one to write. Writing `Desktop` on a node whose
+            // desktop and lock screen are linked put the wallpaper somewhere
+            // macOS never reads, which is issue #11.
+            let changed = AppleWallpaperStore.applyChoice(
+                choice, to: &store, targetKey: targetKey
+            )
 
-            if targetKey != "all", changed == 0 {
-                ensureDisplaySurface(
-                    named: "Desktop",
-                    displayUUID: targetKey,
-                    choice: choice,
-                    fallback: firstSurface(named: "Desktop", in: store) ?? defaultSurface(),
-                    root: &store
-                )
-            } else if targetKey == "all", changed == 0 {
-                // A real store can carry no `Desktop` key at all: on this Mac
-                // the top-level `AllSpacesAndDisplays` node held only `Idle`,
-                // so an all-displays apply matched nothing and wrote nothing.
-                // Create the node that means "everywhere" rather than
-                // succeeding silently against an empty tree.
-                ensureAllSpacesSurface(
-                    named: "Desktop",
-                    choice: choice,
-                    fallback: firstSurface(named: "Desktop", in: store) ?? defaultSurface(),
-                    root: &store
-                )
+            if changed == 0 {
+                // A real store can offer nowhere to write: one reporter's Mac
+                // kept every node linked, so an apply looking only for
+                // `Desktop` matched nothing at all. Create the node that means
+                // "everywhere" rather than succeeding silently against a tree
+                // with no room in it.
+                let desktopFallback = firstNonMuroSurface(named: "Desktop", in: store)
+                    ?? defaultSurface()
+                let idleFallback = firstNonMuroSurface(named: "Idle", in: store)
+                    ?? defaultSurface()
+                if targetKey == "all" {
+                    ensureNode(
+                        at: ["AllSpacesAndDisplays"],
+                        choice: choice,
+                        desktopFallback: desktopFallback,
+                        idleFallback: idleFallback,
+                        root: &store
+                    )
+                } else {
+                    ensureNode(
+                        at: ["Displays", targetKey],
+                        choice: choice,
+                        desktopFallback: desktopFallback,
+                        idleFallback: idleFallback,
+                        root: &store
+                    )
+                }
             }
 
             try writePropertyList(store, to: storeURL)
@@ -892,10 +884,9 @@ final class LockScreenService {
 
     /// A Muro record is dead when the video it names is no longer staged.
     ///
-    /// Dead records are the whole failure: macOS still believes Muro owns the
-    /// surface, asks the extension for that wallpaper, and the extension has
-    /// nothing to hand back, so the lock screen falls back to Apple's default
-    /// and the extension log fills with `no staged lock-screen library`.
+    /// Dead records leave macOS believing Muro owns the surface: it asks the
+    /// extension for a wallpaper whose file is gone, gets nothing back, and
+    /// shows Apple's default instead.
     ///
     /// Deliberately keyed on the staged file rather than on Muro's own
     /// selection list. A wallpaper picked straight from System Settings never
@@ -908,15 +899,6 @@ final class LockScreenService {
         return !FileManager.default.fileExists(atPath: stagedVideoURL(id: id).path)
     }
 
-    private static func firstSurface(named name: String, in value: Any) -> [String: Any]? {
-        if let dictionary = value as? [String: Any] {
-            if let surface = dictionary[name] as? [String: Any] { return surface }
-            for child in dictionary.values {
-                if let found = firstSurface(named: name, in: child) { return found }
-            }
-        }
-        return nil
-    }
 
     private static func firstNonMuroSurface(named name: String, in value: Any) -> [String: Any]? {
         if let dictionary = value as? [String: Any] {
@@ -955,46 +937,50 @@ final class LockScreenService {
         return current as? [String: Any]
     }
 
-    private static func surfaceApplying(
+    /// Writes the choice at one path in the tree, whether or not a node is
+    /// already there.
+    ///
+    /// Replaces two helpers that each bolted a `Desktop` key onto whatever
+    /// they found and stamped `Type` as `individual` without adding the `Idle`
+    /// that word promises. That left nodes describing a shape they did not
+    /// have, and one reporter's Mac carried exactly that while macOS never
+    /// asked the extension for a single frame.
+    private static func ensureNode(
+        at path: [String],
         choice: [String: Any],
-        to surface: [String: Any]
-    ) -> [String: Any] {
-        var updated = surface
-        var content = updated["Content"] as? [String: Any] ?? [:]
-        content["Choices"] = [choice]
-        if content["Shuffle"] == nil { content["Shuffle"] = "$null" }
-        updated["Content"] = content
-        updated["LastSet"] = Date()
-        updated["LastUse"] = Date()
-        return updated
-    }
-
-    private static func ensureDisplaySurface(
-        named name: String,
-        displayUUID: String,
-        choice: [String: Any],
-        fallback: [String: Any],
+        desktopFallback: [String: Any],
+        idleFallback: [String: Any],
         root: inout Any
     ) {
-        guard var rootDictionary = root as? [String: Any] else { return }
-        var displays = rootDictionary["Displays"] as? [String: Any] ?? [:]
-        var display = displays[displayUUID] as? [String: Any] ?? ["Type": "individual"]
-        display[name] = surfaceApplying(choice: choice, to: fallback)
-        displays[displayUUID] = display
-        rootDictionary["Displays"] = displays
-        root = rootDictionary
-    }
-
-    private static func ensureAllSpacesSurface(
-        named name: String,
-        choice: [String: Any],
-        fallback: [String: Any],
-        root: inout Any
-    ) {
-        guard var rootDictionary = root as? [String: Any] else { return }
-        var node = rootDictionary["AllSpacesAndDisplays"] as? [String: Any] ?? [:]
-        node[name] = surfaceApplying(choice: choice, to: fallback)
-        rootDictionary["AllSpacesAndDisplays"] = node
+        guard let first = path.first, var rootDictionary = root as? [String: Any] else { return }
+        if path.count == 1 {
+            let existing = rootDictionary[first] as? [String: Any]
+            rootDictionary[first] = existing.map {
+                AppleWallpaperStore.nodeApplying(
+                    choice: choice,
+                    to: $0,
+                    desktopFallback: desktopFallback,
+                    idleFallback: idleFallback
+                )
+            } ?? AppleWallpaperStore.makeNode(
+                choice: choice,
+                desktopFallback: desktopFallback,
+                idleFallback: idleFallback
+            )
+            root = rootDictionary
+            return
+        }
+        var container = rootDictionary[first] as? [String: Any] ?? [:]
+        var nested: Any = container
+        ensureNode(
+            at: Array(path.dropFirst()),
+            choice: choice,
+            desktopFallback: desktopFallback,
+            idleFallback: idleFallback,
+            root: &nested
+        )
+        container = nested as? [String: Any] ?? container
+        rootDictionary[first] = container
         root = rootDictionary
     }
 
@@ -1088,9 +1074,24 @@ final class LockScreenService {
         error: Error? = nil
     ) {
         let version = ProcessInfo.processInfo.operatingSystemVersionString
+        // Names the surface Muro actually landed on and the node's own
+        // `Type`, rather than a bare yes or no. The whole of issue #11 was
+        // Muro writing the wrong one of three keys, and "ok" said nothing
+        // about which one, so the first report of it was unanswerable.
         let stores = wallpaperStoreURLs.map { url -> String in
-            let has = containsMuroSurface(named: "Desktop", in: loadWallpaperStore(at: url))
-            return "\(url.lastPathComponent)=\(has ? "ok" : "no")"
+            var seen: Set<String> = []
+            if let store = loadWallpaperStore(at: url) {
+                AppleWallpaperStore.forEachNode(in: store) { _, node in
+                    for name in AppleWallpaperStore.surfaceNames {
+                        guard let surface = node[name] as? [String: Any],
+                              AppleWallpaperStore.providers(of: surface).contains(extensionBundleID)
+                        else { continue }
+                        seen.insert("\(name)/\(node["Type"] as? String ?? "none")")
+                    }
+                }
+            }
+            let detail = seen.isEmpty ? "no" : seen.sorted().joined(separator: ",")
+            return "\(url.lastPathComponent)=\(detail)"
         }.joined(separator: " ")
         let line = [
             ISO8601DateFormatter().string(from: Date()),

--- a/Muro/Sources/MuroApp/LockScreenService.swift
+++ b/Muro/Sources/MuroApp/LockScreenService.swift
@@ -115,14 +115,40 @@ final class LockScreenService {
         // moment. Cheap when there is nothing to clear (two `getxattr` calls).
         await Task.detached(priority: .utility) { Self.clearQuarantine() }.value
 
-        guard !activeWallpaperIDs.isEmpty else { return }
         let root = self.root
         let extensionURL = extensionBundleURL
+
+        // Muro claiming nothing is not the same as Apple holding nothing. A
+        // record can outlive the wallpaper it names, and this branch used to
+        // return before it could ever look. The result was a Mac where macOS
+        // asked Muro for a lock-screen wallpaper on every wake, Muro answered
+        // with nothing because the file was gone, and neither side knew: the
+        // app showed no lock-screen wallpaper set, so there was nothing to
+        // suggest anything was wrong.
+        guard !activeWallpaperIDs.isEmpty else {
+            let changed = await Task.detached(priority: .utility) {
+                (try? Self.purgeDeadMuroSurfaces(root: root)) == true
+            }.value
+            if changed {
+                await Task.detached(priority: .utility) { Self.restartWallpaperAgent() }.value
+            }
+            return
+        }
 
         let stillSelected = await Task.detached(priority: .utility) {
             Self.wallpaperStoresHaveSelection()
         }.value
-        guard !stillSelected else { return }
+        // A healthy selection can still sit alongside records left by earlier
+        // wallpapers, so this path sweeps rather than simply returning.
+        guard !stillSelected else {
+            let changed = await Task.detached(priority: .utility) {
+                (try? Self.purgeDeadMuroSurfaces(root: root)) == true
+            }.value
+            if changed {
+                await Task.detached(priority: .utility) { Self.restartWallpaperAgent() }.value
+            }
+            return
+        }
 
         await Task.detached(priority: .utility) {
             try? await Self.restoreWallpaperStores(targetKey: "all", root: root)
@@ -228,6 +254,14 @@ final class LockScreenService {
                 try Self.pruneStagedLibrary(
                     keeping: Set(nextState.selections.values).subtracting([Self.removedSelection])
                 )
+                // The wallpaper this one replaced has just lost its staged
+                // file, so every record still naming it is now dead. Sweeping
+                // here is what stops the stores growing a layer per wallpaper.
+                // The live record is untouched, so the agent only re-reads
+                // what it is already showing.
+                if (try? Self.purgeDeadMuroSurfaces(root: root)) == true {
+                    Self.restartWallpaperAgent()
+                }
                 if !settled {
                     // Everything Muro owns is written and the extension is
                     // registered. Only macOS has not acknowledged it. Keep the
@@ -296,6 +330,13 @@ final class LockScreenService {
             try Self.pruneStagedLibrary(
                 keeping: Set(nextState.selections.values).subtracting([Self.removedSelection])
             )
+            // `restoreWallpaperStores` only rewrites surfaces matching this
+            // target. Records for the same wallpaper under a display that is
+            // no longer connected, or under another Space, are not matched and
+            // used to survive a removal forever.
+            if (try? Self.purgeDeadMuroSurfaces(root: root)) == true {
+                Self.restartWallpaperAgent()
+            }
             if nextState.selections.values.allSatisfy({ $0 == Self.removedSelection }) {
                 Self.unregisterExtension(at: extensionURL)
                 try? FileManager.default.removeItem(at: Self.backupDirectoryURL(root: root))
@@ -679,6 +720,52 @@ final class LockScreenService {
         }
     }
 
+    /// Takes every dead Muro record out of Apple's stores and gives the
+    /// surface back to whatever the user had.
+    ///
+    /// Needed because a wallpaper apply fans out. Apple keeps one `Desktop`
+    /// surface per Space per display and the write walks all of them, so a Mac
+    /// that has used the feature for a while accumulates a record per Space
+    /// for every wallpaper it has ever shown. Removing one wallpaper only ever
+    /// rewrote the surfaces matching that target, so the rest sat there
+    /// pointing at videos that had since been deleted: measured at 139 of 356
+    /// records on the developer's own Mac, with the two stores disagreeing
+    /// about which wallpaper was current.
+    ///
+    /// Returns whether anything changed, so the caller only restarts
+    /// WallpaperAgent when there is a reason to.
+    @discardableResult
+    private static func purgeDeadMuroSurfaces(root: URL) throws -> Bool {
+        let manager = FileManager.default
+        var changedAnyStore = false
+        for storeURL in wallpaperStoreURLs where manager.fileExists(atPath: storeURL.path) {
+            let data = try Data(contentsOf: storeURL)
+            var current = try PropertyListSerialization.propertyList(from: data, format: nil)
+            let backup = (try? Data(contentsOf: backupURL(root: root, storeName: storeURL.lastPathComponent)))
+                .flatMap { try? PropertyListSerialization.propertyList(from: $0, format: nil) }
+            var changed = false
+
+            for surfaceName in ["Desktop", "Idle", "Linked"] {
+                let fallback = backup.flatMap { firstNonMuroSurface(named: surfaceName, in: $0) }
+                    ?? firstNonMuroSurface(named: surfaceName, in: current)
+                    ?? crossStoreNonMuroSurface(named: surfaceName)
+                    ?? defaultSurface()
+                mutateSurfaces(named: surfaceName, in: &current, path: []) { path, surface in
+                    guard isDeadMuroSurface(surface) else { return surface }
+                    changed = true
+                    return backup.flatMap { self.surface(named: surfaceName, at: path, in: $0) }
+                        .flatMap { isMuroSurface($0) ? nil : $0 }
+                        ?? fallback
+                }
+            }
+
+            guard changed else { continue }
+            try writePropertyList(current, to: storeURL)
+            changedAnyStore = true
+        }
+        return changedAnyStore
+    }
+
     private static func writePropertyList(_ value: Any, to url: URL) throws {
         let data = try PropertyListSerialization.data(
             fromPropertyList: value,
@@ -726,6 +813,37 @@ final class LockScreenService {
               let choices = content["Choices"] as? [[String: Any]]
         else { return false }
         return choices.contains { ($0["Provider"] as? String) == extensionBundleID }
+    }
+
+    /// The wallpaper this Muro record asks the extension to play. macOS hands
+    /// the same bytes back on `acquire`, so it is what the extension looks up.
+    private static func muroWallpaperID(of surface: [String: Any]) -> String? {
+        guard let content = surface["Content"] as? [String: Any],
+              let choices = content["Choices"] as? [[String: Any]]
+        else { return nil }
+        for choice in choices where (choice["Provider"] as? String) == extensionBundleID {
+            guard let data = choice["Configuration"] as? Data else { continue }
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
+
+    /// A Muro record is dead when the video it names is no longer staged.
+    ///
+    /// Dead records are the whole failure: macOS still believes Muro owns the
+    /// surface, asks the extension for that wallpaper, and the extension has
+    /// nothing to hand back, so the lock screen falls back to Apple's default
+    /// and the extension log fills with `no staged lock-screen library`.
+    ///
+    /// Deliberately keyed on the staged file rather than on Muro's own
+    /// selection list. A wallpaper picked straight from System Settings never
+    /// reaches `lockscreen.json`, so judging by the selection list would tear
+    /// out a choice the user made by hand. A record naming a file that does
+    /// not exist cannot be anybody's working choice.
+    private static func isDeadMuroSurface(_ surface: [String: Any]) -> Bool {
+        guard isMuroSurface(surface) else { return false }
+        guard let id = muroWallpaperID(of: surface), !id.isEmpty else { return true }
+        return !FileManager.default.fileExists(atPath: stagedVideoURL(id: id).path)
     }
 
     private static func firstSurface(named name: String, in value: Any) -> [String: Any]? {

--- a/Muro/Sources/MuroKit/AppleWallpaperStore.swift
+++ b/Muro/Sources/MuroKit/AppleWallpaperStore.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+/// The shape of Apple's own wallpaper store, and the one rule Muro has to
+/// follow when writing into it.
+///
+/// `~/Library/Application Support/com.apple.wallpaper/Store/Index.plist`, and
+/// its sibling `Index2.plist`, hold a tree of nodes: one per Space, one per
+/// display, plus a system default. Each node keeps its wallpaper under a
+/// surface key, and carries a `Type` saying which key that is. macOS's own
+/// `WallpaperAgent` knows four types and three surfaces:
+///
+/// | `Type`       | What the node carries              |
+/// |--------------|------------------------------------|
+/// | `individual` | `Desktop` and `Idle`, kept apart   |
+/// | `linked`     | `Linked`, one wallpaper for both   |
+/// | `desktop`    | `Desktop` only                     |
+/// | `idle`       | `Idle` only, the screen saver      |
+///
+/// **The lock screen has no surface of its own.** WallpaperAgent's runtime
+/// knows only `linked`, `desktop` and `screenSaver`, so the lock screen
+/// renders whatever fills the desktop role: `Desktop` on an individual node,
+/// `Linked` on a linked one.
+///
+/// Muro used to write `Desktop` on every node regardless of its `Type`. On a
+/// Mac whose desktop and lock screen are linked, that put the wallpaper under
+/// a key macOS never reads, so the lock screen went on showing whatever
+/// `Linked` still held, which is Apple's own wallpaper. That is issue #11, and
+/// it is why picking the same wallpaper by hand in System Settings worked
+/// while applying it from inside Muro did not.
+///
+/// This lives in MuroKit rather than beside `LockScreenService` for one
+/// reason: none of it can be exercised on the machine it was written on. The
+/// developer's Mac runs macOS 27 and has never held a linked node, so the only
+/// way to know this is right is to rebuild each reported shape as a plist and
+/// assert on the result.
+public enum AppleWallpaperStore {
+    /// Every key a node can keep a wallpaper under.
+    public static let surfaceNames = ["Desktop", "Idle", "Linked"]
+
+    /// A dictionary is a wallpaper node when it carries at least one surface.
+    ///
+    /// Deliberately not keyed on `Type`: a node can be missing it, and the
+    /// containers above these nodes (`Spaces`, `Displays`) carry neither.
+    public static func isWallpaperNode(_ node: [String: Any]) -> Bool {
+        surfaceNames.contains { node[$0] is [String: Any] }
+    }
+
+    /// The key this node keeps the wallpaper the lock screen renders under, or
+    /// `nil` when Muro has no business writing to this node at all.
+    ///
+    /// `idle` is the screen saver on its own. Writing there would make Muro
+    /// the screen saver rather than the wallpaper, which is not what anybody
+    /// asked for, so those nodes are left alone. A node carrying no `Type` at
+    /// all keeps the old behaviour and gets `Desktop`.
+    public static func desktopSurfaceName(of node: [String: Any]) -> String? {
+        switch node["Type"] as? String {
+        case "linked": return "Linked"
+        case "idle": return nil
+        default: return "Desktop"
+        }
+    }
+
+    /// Puts one choice into a surface, leaving everything else about it alone.
+    ///
+    /// `Content` is preserved rather than replaced so a surface keeps whatever
+    /// else macOS put there, and `Shuffle` is only filled in when it is
+    /// missing.
+    public static func surfaceApplying(
+        choice: [String: Any],
+        to surface: [String: Any],
+        now: Date = Date()
+    ) -> [String: Any] {
+        var updated = surface
+        var content = updated["Content"] as? [String: Any] ?? [:]
+        content["Choices"] = [choice]
+        if content["Shuffle"] == nil { content["Shuffle"] = "$null" }
+        updated["Content"] = content
+        updated["LastSet"] = now
+        updated["LastUse"] = now
+        return updated
+    }
+
+    /// Walks every wallpaper node in the tree, letting the caller rewrite it.
+    ///
+    /// Recursion stops at a surface key, so nothing inside a `Content`
+    /// dictionary is ever mistaken for a node of its own.
+    public static func mutateNodes(
+        in value: inout Any,
+        path: [String] = [],
+        transform: ([String], [String: Any]) -> [String: Any]
+    ) {
+        guard var dictionary = value as? [String: Any] else { return }
+        if isWallpaperNode(dictionary) {
+            dictionary = transform(path, dictionary)
+        }
+        // Snapshot the keys: `transform` above may have added or removed some.
+        for key in Array(dictionary.keys) where !surfaceNames.contains(key) {
+            guard var child = dictionary[key] else { continue }
+            mutateNodes(in: &child, path: path + [key], transform: transform)
+            dictionary[key] = child
+        }
+        value = dictionary
+    }
+
+    /// Read-only twin of `mutateNodes`.
+    public static func forEachNode(
+        in value: Any,
+        path: [String] = [],
+        _ body: ([String], [String: Any]) -> Void
+    ) {
+        guard let dictionary = value as? [String: Any] else { return }
+        if isWallpaperNode(dictionary) { body(path, dictionary) }
+        for (key, child) in dictionary where !surfaceNames.contains(key) {
+            forEachNode(in: child, path: path + [key], body)
+        }
+    }
+
+    /// The providers named by a surface, in order.
+    public static func providers(of surface: [String: Any]) -> [String] {
+        guard let content = surface["Content"] as? [String: Any],
+              let choices = content["Choices"] as? [[String: Any]]
+        else { return [] }
+        return choices.compactMap { $0["Provider"] as? String }
+    }
+
+    /// Whether any surface anywhere in the store names `provider`.
+    ///
+    /// Looks at all three surfaces. The old check looked only at `Desktop`, so
+    /// on a linked Mac a perfectly good apply read back as a failure and the
+    /// user was told to go and use System Settings.
+    public static func containsProvider(_ provider: String, in store: Any?) -> Bool {
+        guard let store else { return false }
+        var found = false
+        forEachNode(in: store) { _, node in
+            for name in surfaceNames {
+                guard let surface = node[name] as? [String: Any] else { continue }
+                if providers(of: surface).contains(provider) { found = true }
+            }
+        }
+        return found
+    }
+
+    /// Writes `choice` into the surface each matching node actually uses.
+    ///
+    /// `targetKey` is either `"all"` or a display UUID, matched against the
+    /// node's path so a single display can be set without touching the rest.
+    ///
+    /// Returns how many nodes were written, so the caller can tell "the store
+    /// had nowhere to put this" apart from "it is written everywhere it
+    /// belongs".
+    @discardableResult
+    public static func applyChoice(
+        _ choice: [String: Any],
+        to store: inout Any,
+        targetKey: String,
+        now: Date = Date()
+    ) -> Int {
+        var written = 0
+        mutateNodes(in: &store) { path, node in
+            guard targetKey == "all" || path.contains(targetKey) else { return node }
+            guard let name = desktopSurfaceName(of: node),
+                  let surface = node[name] as? [String: Any]
+            else { return node }
+            written += 1
+            var updated = node
+            updated[name] = surfaceApplying(choice: choice, to: surface, now: now)
+            return updated
+        }
+        return written
+    }
+
+    /// Puts the choice on one node, creating the surface key when the node
+    /// does not have one yet.
+    ///
+    /// An existing `Type` is never rewritten. That field records how the user
+    /// arranged their own desktop and lock screen, and changing it would
+    /// silently link or unlink the two behind their back. The single exception
+    /// is a screen-saver-only node, which has to gain a desktop surface before
+    /// it can hold one, and is then labelled honestly.
+    public static func nodeApplying(
+        choice: [String: Any],
+        to node: [String: Any],
+        desktopFallback: [String: Any],
+        idleFallback: [String: Any],
+        now: Date = Date()
+    ) -> [String: Any] {
+        var updated = node
+        if let name = desktopSurfaceName(of: node) {
+            let base = node[name] as? [String: Any] ?? desktopFallback
+            updated[name] = surfaceApplying(choice: choice, to: base, now: now)
+            return updated
+        }
+        updated["Desktop"] = surfaceApplying(choice: choice, to: desktopFallback, now: now)
+        if updated["Idle"] == nil { updated["Idle"] = idleFallback }
+        updated["Type"] = "individual"
+        return updated
+    }
+
+    /// A node built from nothing, in the one shape observed to work: an
+    /// `individual` node carrying both a `Desktop` holding our choice and an
+    /// `Idle` left to the system.
+    ///
+    /// The old code stamped `Type` as `individual` while writing a `Desktop`
+    /// and no `Idle`, which describes a node that cannot exist. One reporter's
+    /// Mac carried exactly that and macOS never once asked the extension for a
+    /// frame.
+    public static func makeNode(
+        choice: [String: Any],
+        desktopFallback: [String: Any],
+        idleFallback: [String: Any],
+        now: Date = Date()
+    ) -> [String: Any] {
+        [
+            "Type": "individual",
+            "Desktop": surfaceApplying(choice: choice, to: desktopFallback, now: now),
+            "Idle": idleFallback,
+        ]
+    }
+
+    /// Whether a node describes itself honestly: every surface it carries is
+    /// one its `Type` allows, and every surface that `Type` promises is there.
+    ///
+    /// Only used by the tests, but it is the invariant the whole file exists
+    /// to keep, so it belongs next to the rules rather than beside them.
+    public static func isWellFormed(_ node: [String: Any]) -> Bool {
+        let present = Set(surfaceNames.filter { node[$0] is [String: Any] })
+        switch node["Type"] as? String {
+        case "individual": return present == ["Desktop", "Idle"]
+        case "linked": return present == ["Linked"]
+        case "desktop": return present == ["Desktop"]
+        case "idle": return present == ["Idle"]
+        default: return true
+        }
+    }
+}

--- a/Muro/Sources/MuroWallpaperExtension/AcquireReceipt.swift
+++ b/Muro/Sources/MuroWallpaperExtension/AcquireReceipt.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// What macOS actually did the last time it asked Muro for a wallpaper.
+///
+/// The app cannot see inside this process, and it used to confirm a lock-screen
+/// apply by re-reading the property list it had just written itself. That check
+/// passes whether or not macOS ever came looking, so an apply that macOS
+/// quietly ignored still reported success and left no trace anywhere.
+///
+/// `acquire` is macOS saying it accepted the choice, and a composited first
+/// frame is the extension saying it could play it. Writing both down is the
+/// only honest evidence the app can wait for.
+///
+/// One slot, overwritten each acquire. The app only ever asks "did a matching
+/// acquire happen after I applied"; the history belongs in `extension.log`.
+/// ISO 8601 on purpose: this file gets pasted into bug reports.
+struct AcquireReceipt: Codable {
+    var id: String
+    var at: Date
+    var ok: Bool
+    var preview: Bool
+    var detail: String
+
+    static var url: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("acquire-receipt.json")
+    }
+
+    static func record(id: String?, preview: Bool, ok: Bool, detail: String) {
+        let receipt = AcquireReceipt(
+            id: id ?? "",
+            at: Date(),
+            ok: ok,
+            preview: preview,
+            detail: detail
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(receipt) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+}

--- a/Muro/Sources/MuroWallpaperExtension/VideoRenderer.swift
+++ b/Muro/Sources/MuroWallpaperExtension/VideoRenderer.swift
@@ -92,18 +92,24 @@ final class VideoRenderer: @unchecked Sendable {
         CATransaction.flush()
     }
 
-    func start(initiallyPaused: Bool, firstFrameReady: @escaping @Sendable () -> Void) {
+    /// `firstFrameReady` carries whether a frame actually reached the layer.
+    ///
+    /// It used to carry nothing, so every caller was told "ready" even when the
+    /// asset would not open. That mattered once the app started waiting on this
+    /// answer to decide whether a lock-screen apply really took.
+    func start(initiallyPaused: Bool, firstFrameReady: @escaping @Sendable (Bool) -> Void) {
         queue.async { [weak self] in
-            guard let self, isRunning else { firstFrameReady(); return }
+            guard let self, isRunning else { firstFrameReady(false); return }
             guard let reader = try? AVAssetReader(asset: asset) else {
-                firstFrameReady()
+                extensionLog("renderer could not open the video")
+                firstFrameReady(false)
                 return
             }
             let output = makeOutput()
             reader.add(output)
             guard reader.startReading() else {
                 extensionLog("renderer could not start reading: \(reader.error?.localizedDescription ?? "unknown")")
-                firstFrameReady()
+                firstFrameReady(false)
                 return
             }
 
@@ -113,6 +119,7 @@ final class VideoRenderer: @unchecked Sendable {
             lastEnqueuedEnd = .zero
             CMTimebaseSetTime(timebase, time: .zero)
 
+            var composited = false
             if let first = output.copyNextSampleBuffer() {
                 CATransaction.begin()
                 CATransaction.setDisableActions(true)
@@ -120,6 +127,7 @@ final class VideoRenderer: @unchecked Sendable {
                 noteEnd(of: first)
                 CATransaction.commit()
                 CATransaction.flush()
+                composited = true
                 extensionTrace("renderer composited first frame")
             } else {
                 extensionLog("renderer produced no first frame")
@@ -127,7 +135,7 @@ final class VideoRenderer: @unchecked Sendable {
 
             isPaused = initiallyPaused
             CMTimebaseSetRate(timebase, rate: initiallyPaused ? 0 : 1)
-            firstFrameReady()
+            firstFrameReady(composited)
             prepareNextReader()
             feedCurrentReader()
         }

--- a/Muro/Sources/MuroWallpaperExtension/main.swift
+++ b/Muro/Sources/MuroWallpaperExtension/main.swift
@@ -160,6 +160,9 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
            let response = createRemoteContextXPC(contextId: existing.context.contextId)
         {
             extensionTrace("reusing remote context \(existing.context.contextId)")
+            AcquireReceipt.record(
+                id: info.choiceID, preview: info.isPreview, ok: true, detail: "reused"
+            )
             reply(response, nil)
             return
         }
@@ -167,6 +170,9 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
         let videoURL = info.files.first { FileManager.default.fileExists(atPath: $0.path) }
             ?? stagedVideoURL(for: info.choiceID)
         guard let videoURL else {
+            AcquireReceipt.record(
+                id: info.choiceID, preview: info.isPreview, ok: false, detail: "not staged"
+            )
             reply(nil, extensionError(2, "The selected Muro video is not staged."))
             return
         }
@@ -177,6 +183,9 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
             ? CAContext.remoteContext()
             : CAContext.perform(NSSelectorFromString("remoteContextWithOptions:"), with: options)?.takeUnretainedValue()
         guard let context = rawContext as? CAContext, context.contextId != 0 else {
+            AcquireReceipt.record(
+                id: info.choiceID, preview: info.isPreview, ok: false, detail: "no context"
+            )
             reply(nil, extensionError(3, "Could not create the remote wallpaper context."))
             return
         }
@@ -189,6 +198,9 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
         CATransaction.flush()
 
         guard let response = createRemoteContextXPC(contextId: context.contextId) else {
+            AcquireReceipt.record(
+                id: info.choiceID, preview: info.isPreview, ok: false, detail: "no remote context"
+            )
             reply(nil, extensionError(4, "Could not wrap the remote wallpaper context."))
             return
         }
@@ -206,12 +218,27 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
             )
             let responseBox = SendableBox(value: response)
             let contextID = context.contextId
-            renderer.start(initiallyPaused: !RendererState.shared.shouldPlayNow(isPreview: info.isPreview)) {
+            let choiceID = info.choiceID
+            let isPreview = info.isPreview
+            renderer.start(initiallyPaused: !RendererState.shared.shouldPlayNow(isPreview: info.isPreview)) { composited in
                 extensionTrace("remote context \(contextID) ready")
+                // Recorded whether or not a frame landed. A paused start still
+                // composites one, so this stays true for the desktop surface,
+                // where the extension is deliberately frozen.
+                AcquireReceipt.record(
+                    id: choiceID,
+                    preview: isPreview,
+                    ok: composited,
+                    detail: composited ? "rendering" : "no first frame"
+                )
                 reply(responseBox.value, nil)
             }
         } catch {
             extensionLog("renderer creation failed: \(error)")
+            AcquireReceipt.record(
+                id: info.choiceID, preview: info.isPreview, ok: false,
+                detail: "renderer failed"
+            )
             reply(nil, extensionError(5, error.localizedDescription))
         }
     }

--- a/Muro/Tests/MuroKitTests/AppleWallpaperStoreTests.swift
+++ b/Muro/Tests/MuroKitTests/AppleWallpaperStoreTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import MuroKit
+
+/// Issue #11: the lock screen kept showing Apple's wallpaper on macOS 26.
+///
+/// None of this can be tried on the machine it was written on. That Mac runs
+/// macOS 27 and has never once held a linked node, so every shape below is
+/// rebuilt from what the three reporters actually pasted into the issue, and
+/// the assertions are the only proof the fix does what it claims.
+final class AppleWallpaperStoreTests: XCTestCase {
+    private let muro = "com.mrrockysl.muro.wallpaper-extension"
+
+    private func choice(_ id: String) -> [String: Any] {
+        ["Provider": muro, "Files": [["relative": "file:///v/\(id).mov"]], "Configuration": Data(id.utf8)]
+    }
+
+    private func surface(provider: String) -> [String: Any] {
+        ["Content": ["Choices": [["Provider": provider]], "Shuffle": "$null"]]
+    }
+
+    private func providers(_ node: Any?, _ key: String) -> [String] {
+        guard let node = node as? [String: Any], let s = node[key] as? [String: Any] else { return [] }
+        return AppleWallpaperStore.providers(of: s)
+    }
+
+    // MARK: - The rule itself
+
+    func testSurfaceNameFollowsType() {
+        XCTAssertEqual(AppleWallpaperStore.desktopSurfaceName(of: ["Type": "linked"]), "Linked")
+        XCTAssertEqual(AppleWallpaperStore.desktopSurfaceName(of: ["Type": "individual"]), "Desktop")
+        XCTAssertEqual(AppleWallpaperStore.desktopSurfaceName(of: ["Type": "desktop"]), "Desktop")
+        XCTAssertEqual(AppleWallpaperStore.desktopSurfaceName(of: [:]), "Desktop")
+    }
+
+    /// The screen saver is not ours to take.
+    func testIdleOnlyNodeIsRefused() {
+        XCTAssertNil(AppleWallpaperStore.desktopSurfaceName(of: ["Type": "idle"]))
+    }
+
+    // MARK: - kernelpanic-root, the reported failure
+
+    /// His store: one node, `Type = linked`, wallpaper under `Linked`.
+    /// The old code wrote `Desktop` here, which macOS never reads.
+    func testLinkedNodeGetsLinkedNotDesktop() {
+        var store: Any = [
+            "AllSpacesAndDisplays": ["Type": "linked", "Linked": surface(provider: "aerials")]
+        ]
+        let written = AppleWallpaperStore.applyChoice(choice("abc"), to: &store, targetKey: "all")
+
+        XCTAssertEqual(written, 1)
+        let node = (store as? [String: Any])?["AllSpacesAndDisplays"]
+        XCTAssertEqual(providers(node, "Linked"), [muro], "the wallpaper must land under Linked")
+        XCTAssertNil((node as? [String: Any])?["Desktop"], "no stray Desktop key on a linked node")
+        XCTAssertTrue(AppleWallpaperStore.isWellFormed(node as! [String: Any]))
+    }
+
+    /// And the apply must then read back as done. The old check looked only at
+    /// `Desktop`, so a correct write reported itself as a failure.
+    func testLinkedWriteIsSeenBySelectionCheck() {
+        var store: Any = ["SystemDefault": ["Type": "linked", "Linked": surface(provider: "aerials")]]
+        XCTAssertFalse(AppleWallpaperStore.containsProvider(muro, in: store))
+        AppleWallpaperStore.applyChoice(choice("abc"), to: &store, targetKey: "all")
+        XCTAssertTrue(AppleWallpaperStore.containsProvider(muro, in: store))
+    }
+
+    // MARK: - The developer's own Mac, which already worked
+
+    /// macOS 27, every node `individual` with both surfaces. Behaviour here
+    /// must not change: this is the one shape known to work today.
+    func testIndividualNodeStillGetsDesktopAndIdleIsUntouched() {
+        var store: Any = [
+            "SystemDefault": [
+                "Type": "individual",
+                "Desktop": surface(provider: "aerials"),
+                "Idle": surface(provider: "default"),
+            ]
+        ]
+        let written = AppleWallpaperStore.applyChoice(choice("abc"), to: &store, targetKey: "all")
+
+        XCTAssertEqual(written, 1)
+        let node = (store as? [String: Any])?["SystemDefault"]
+        XCTAssertEqual(providers(node, "Desktop"), [muro])
+        XCTAssertEqual(providers(node, "Idle"), ["default"], "the screen saver stays the user's")
+        XCTAssertNil((node as? [String: Any])?["Linked"])
+    }
+
+    /// An `idle` node sits beside the others on that Mac and must be skipped.
+    func testIdleNodeIsLeftAloneWhileOthersAreWritten() {
+        var store: Any = [
+            "AllSpacesAndDisplays": ["Type": "idle", "Idle": surface(provider: "default")],
+            "SystemDefault": [
+                "Type": "individual",
+                "Desktop": surface(provider: "aerials"),
+                "Idle": surface(provider: "default"),
+            ],
+        ]
+        let written = AppleWallpaperStore.applyChoice(choice("abc"), to: &store, targetKey: "all")
+
+        XCTAssertEqual(written, 1, "only the individual node is ours")
+        let idle = (store as? [String: Any])?["AllSpacesAndDisplays"]
+        XCTAssertEqual(providers(idle, "Idle"), ["default"])
+        XCTAssertNil((idle as? [String: Any])?["Desktop"])
+    }
+
+    // MARK: - aptonline, the malformed node
+
+    /// His node claims `individual` but carries only a `Desktop`, a shape that
+    /// cannot exist. Muro built it, and macOS never asked his extension for a
+    /// single frame.
+    func testCreatedNodeIsWellFormed() {
+        let node = AppleWallpaperStore.makeNode(
+            choice: choice("abc"),
+            desktopFallback: surface(provider: "default"),
+            idleFallback: surface(provider: "default")
+        )
+        XCTAssertEqual(node["Type"] as? String, "individual")
+        XCTAssertEqual(providers(node, "Desktop"), [muro])
+        XCTAssertNotNil(node["Idle"], "individual promises an Idle, so there must be one")
+        XCTAssertTrue(AppleWallpaperStore.isWellFormed(node))
+    }
+
+    func testTheOldMalformedShapeIsRecognisedAsWrong() {
+        XCTAssertFalse(AppleWallpaperStore.isWellFormed([
+            "Type": "individual", "Desktop": surface(provider: "muro"),
+        ]))
+        XCTAssertFalse(AppleWallpaperStore.isWellFormed([
+            "Type": "linked", "Desktop": surface(provider: "muro"),
+        ]))
+    }
+
+    // MARK: - nodeApplying
+
+    /// A node's own `Type` is the user's arrangement of their desktop and lock
+    /// screen. Muro must never quietly relink or unlink them.
+    func testNodeApplyingNeverRewritesAnExistingType() {
+        let node = AppleWallpaperStore.nodeApplying(
+            choice: choice("abc"),
+            to: ["Type": "linked", "Linked": surface(provider: "aerials")],
+            desktopFallback: surface(provider: "default"),
+            idleFallback: surface(provider: "default")
+        )
+        XCTAssertEqual(node["Type"] as? String, "linked")
+        XCTAssertEqual(providers(node, "Linked"), [muro])
+    }
+
+    /// The one exception: a screen-saver-only node has to gain a desktop
+    /// surface before it can hold one, and must then say so.
+    func testIdleOnlyNodeGainsADesktopAndSaysSo() {
+        let node = AppleWallpaperStore.nodeApplying(
+            choice: choice("abc"),
+            to: ["Type": "idle", "Idle": surface(provider: "default")],
+            desktopFallback: surface(provider: "default"),
+            idleFallback: surface(provider: "default")
+        )
+        XCTAssertEqual(node["Type"] as? String, "individual")
+        XCTAssertEqual(providers(node, "Desktop"), [muro])
+        XCTAssertEqual(providers(node, "Idle"), ["default"])
+        XCTAssertTrue(AppleWallpaperStore.isWellFormed(node))
+    }
+
+    // MARK: - Targeting one display
+
+    func testASingleDisplayTargetLeavesTheOthersAlone() {
+        let uuid = "AAAA-1111"
+        var store: Any = [
+            "Displays": [
+                uuid: ["Type": "individual", "Desktop": surface(provider: "aerials"), "Idle": surface(provider: "default")],
+                "BBBB-2222": ["Type": "individual", "Desktop": surface(provider: "aerials"), "Idle": surface(provider: "default")],
+            ]
+        ]
+        let written = AppleWallpaperStore.applyChoice(choice("abc"), to: &store, targetKey: uuid)
+
+        XCTAssertEqual(written, 1)
+        let displays = (store as? [String: Any])?["Displays"] as? [String: Any]
+        XCTAssertEqual(providers(displays?[uuid], "Desktop"), [muro])
+        XCTAssertEqual(providers(displays?["BBBB-2222"], "Desktop"), ["aerials"], "the other display is untouched")
+    }
+
+    // MARK: - Walking
+
+    /// A `Content` dictionary is not a node, however deep the tree goes.
+    func testContentIsNeverMistakenForANode() {
+        let store: Any = [
+            "Spaces": ["S1": ["Default": [
+                "Type": "individual",
+                "Desktop": ["Content": ["Choices": [["Provider": "aerials", "Desktop": ["x": 1]]]]],
+                "Idle": surface(provider: "default"),
+            ]]]
+        ]
+        var count = 0
+        AppleWallpaperStore.forEachNode(in: store) { _, _ in count += 1 }
+        XCTAssertEqual(count, 1)
+    }
+
+    func testEmptyAndOddInputsDoNotCrash() {
+        var empty: Any = [String: Any]()
+        XCTAssertEqual(AppleWallpaperStore.applyChoice(choice("a"), to: &empty, targetKey: "all"), 0)
+        var notADictionary: Any = [1, 2, 3]
+        XCTAssertEqual(AppleWallpaperStore.applyChoice(choice("a"), to: &notADictionary, targetKey: "all"), 0)
+        XCTAssertFalse(AppleWallpaperStore.containsProvider(muro, in: nil))
+    }
+
+    /// Applying twice must not pile up choices or duplicate surfaces.
+    func testApplyingTwiceIsStable() {
+        var store: Any = ["SystemDefault": ["Type": "linked", "Linked": surface(provider: "aerials")]]
+        AppleWallpaperStore.applyChoice(choice("one"), to: &store, targetKey: "all")
+        AppleWallpaperStore.applyChoice(choice("two"), to: &store, targetKey: "all")
+        let node = (store as? [String: Any])?["SystemDefault"] as? [String: Any]
+        let choices = ((node?["Linked"] as? [String: Any])?["Content"] as? [String: Any])?["Choices"] as? [[String: Any]]
+        XCTAssertEqual(choices?.count, 1)
+        XCTAssertEqual(choices?.first?["Configuration"] as? Data, Data("two".utf8))
+    }
+}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -138,18 +138,26 @@ Muro stores local data in:
 - The `com.mrrockysl.muro` preferences domain for interface and catalog settings
 - The wallpaper extension's container for staged lock-screen files and its
   local diagnostic log
-- `~/Library/Application Support/Muro/lockscreen-diagnostics.log`, written only
-  when a lock-screen apply fails or is not acknowledged by macOS
+- `~/Library/Application Support/Muro/lockscreen-diagnostics.log`, written on
+  every lock-screen apply
 
 The extension log records technical lifecycle events such as process IDs,
 wallpaper and display identifiers, requested dimensions, and errors. Since 3.0
 it is size-capped rather than growing without limit.
 
 The lock-screen diagnostics log records the macOS version, the wallpaper and
-target identifiers, whether the extension was registered, and which wallpaper
-store did not accept the change. It exists so a failure report can be answered.
-It is capped at 32 KB and, like the extension log, contains no video contents
-and is never uploaded.
+target identifiers, whether the extension was registered, whether the wallpaper
+stores kept the change, and whether macOS acknowledged it. It exists so a
+failure report can be answered. Since 4.0 it is written on every apply rather
+than only on a failure, because an apply that reported success and did nothing
+used to leave no record at all. It is capped at 32 KB and, like the extension
+log, contains no video contents and is never uploaded.
+
+The extension also writes a small `acquire-receipt.json` inside its own
+container, holding the identifier of the wallpaper macOS last asked it for, the
+time, and whether a frame was drawn. Muro reads it to tell an apply that macOS
+genuinely collected apart from one it only wrote down. It is a single record,
+overwritten each time, and is never uploaded.
 
 ### Dependencies and release contents
 


### PR DESCRIPTION
On macOS 26 the lock screen kept showing Apple's wallpaper instead of the applied one.

macOS keeps a wallpaper under one of three keys and says which in a Type field beside it: Desktop and Idle when the desktop and lock screen are set apart, Linked when they share one. Muro wrote Desktop every time, so on a Mac with the two linked the wallpaper went somewhere macOS never looks. Picking the same wallpaper by hand in System Settings worked, which is what made it look like our bug rather than a missing key. The rules now live in MuroKit with tests built from the shapes three people pasted into the issue.

Two things that hid the failure are in here as well. Apply used to write the choice into Apple's store and then read that same store back to decide whether it had worked, so the check passed every time and macOS ignoring the choice read as success. It now waits for a receipt from the extension, which is the one thing Muro cannot fake. And dead records naming deleted wallpapers were left behind by every apply, which is how a Mac ends up being asked for a wallpaper it cannot supply.

Reported in #11. None of it could be reproduced here, on macOS 27, so leaving that issue open until someone on 26 confirms.
