### PR TITLE
Put the lock screen wallpaper where a Mac with one screen keeps it

### DIFF
--- a/Muro/Sources/MuroApp/LockScreenService.swift
+++ b/Muro/Sources/MuroApp/LockScreenService.swift
@@ -692,39 +692,16 @@ final class LockScreenService {
             // Each node says which surface it keeps its wallpaper under, and
             // that is the one to write. Writing `Desktop` on a node whose
             // desktop and lock screen are linked put the wallpaper somewhere
-            // macOS never reads, which is issue #11.
-            let changed = AppleWallpaperStore.applyChoice(
-                choice, to: &store, targetKey: targetKey
+            // macOS never reads, which is issue #11. A store can also offer
+            // no node for this display at all, and then the choice goes where
+            // that store already keeps its wallpaper.
+            AppleWallpaperStore.applyChoiceCreatingNode(
+                choice,
+                to: &store,
+                targetKey: targetKey,
+                desktopFallback: firstNonMuroSurface(named: "Desktop", in: store) ?? defaultSurface(),
+                idleFallback: firstNonMuroSurface(named: "Idle", in: store) ?? defaultSurface()
             )
-
-            if changed == 0 {
-                // A real store can offer nowhere to write: one reporter's Mac
-                // kept every node linked, so an apply looking only for
-                // `Desktop` matched nothing at all. Create the node that means
-                // "everywhere" rather than succeeding silently against a tree
-                // with no room in it.
-                let desktopFallback = firstNonMuroSurface(named: "Desktop", in: store)
-                    ?? defaultSurface()
-                let idleFallback = firstNonMuroSurface(named: "Idle", in: store)
-                    ?? defaultSurface()
-                if targetKey == "all" {
-                    ensureNode(
-                        at: ["AllSpacesAndDisplays"],
-                        choice: choice,
-                        desktopFallback: desktopFallback,
-                        idleFallback: idleFallback,
-                        root: &store
-                    )
-                } else {
-                    ensureNode(
-                        at: ["Displays", targetKey],
-                        choice: choice,
-                        desktopFallback: desktopFallback,
-                        idleFallback: idleFallback,
-                        root: &store
-                    )
-                }
-            }
 
             try writePropertyList(store, to: storeURL)
             // Written twice with a pause, because WallpaperAgent may rewrite
@@ -856,7 +833,7 @@ final class LockScreenService {
     ) {
         mutateSurfaces(named: name, in: &value, path: path) { surfacePath, surface in
             guard isMuroSurface(surface),
-                  targetKey == "all" || surfacePath.contains(targetKey)
+                  AppleWallpaperStore.surfaceBelongsToTarget(surfacePath, targetKey: targetKey)
             else { return surface }
             return replacement(surfacePath, surface)
         }
@@ -935,53 +912,6 @@ final class LockScreenService {
             current = next
         }
         return current as? [String: Any]
-    }
-
-    /// Writes the choice at one path in the tree, whether or not a node is
-    /// already there.
-    ///
-    /// Replaces two helpers that each bolted a `Desktop` key onto whatever
-    /// they found and stamped `Type` as `individual` without adding the `Idle`
-    /// that word promises. That left nodes describing a shape they did not
-    /// have, and one reporter's Mac carried exactly that while macOS never
-    /// asked the extension for a single frame.
-    private static func ensureNode(
-        at path: [String],
-        choice: [String: Any],
-        desktopFallback: [String: Any],
-        idleFallback: [String: Any],
-        root: inout Any
-    ) {
-        guard let first = path.first, var rootDictionary = root as? [String: Any] else { return }
-        if path.count == 1 {
-            let existing = rootDictionary[first] as? [String: Any]
-            rootDictionary[first] = existing.map {
-                AppleWallpaperStore.nodeApplying(
-                    choice: choice,
-                    to: $0,
-                    desktopFallback: desktopFallback,
-                    idleFallback: idleFallback
-                )
-            } ?? AppleWallpaperStore.makeNode(
-                choice: choice,
-                desktopFallback: desktopFallback,
-                idleFallback: idleFallback
-            )
-            root = rootDictionary
-            return
-        }
-        var container = rootDictionary[first] as? [String: Any] ?? [:]
-        var nested: Any = container
-        ensureNode(
-            at: Array(path.dropFirst()),
-            choice: choice,
-            desktopFallback: desktopFallback,
-            idleFallback: idleFallback,
-            root: &nested
-        )
-        container = nested as? [String: Any] ?? container
-        rootDictionary[first] = container
-        root = rootDictionary
     }
 
     private static func defaultSurface() -> [String: Any] {

--- a/Muro/Sources/MuroKit/AppleWallpaperStore.swift
+++ b/Muro/Sources/MuroKit/AppleWallpaperStore.swift
@@ -169,6 +169,142 @@ public enum AppleWallpaperStore {
         return written
     }
 
+    /// The nodes a store already keeps a shared wallpaper in, nearest first.
+    ///
+    /// `AllSpacesAndDisplays` is the one macOS reads when a display has no
+    /// node of its own. `SystemDefault` sits behind it and Apple writes both,
+    /// so both are offered.
+    public static let sharedNodePaths = [["AllSpacesAndDisplays"], ["SystemDefault"]]
+
+    /// Whether a wallpaper node already sits at `path`.
+    public static func hasNode(at path: [String], in store: Any) -> Bool {
+        var current = store
+        for component in path {
+            guard let dictionary = current as? [String: Any],
+                  let next = dictionary[component]
+            else { return false }
+            current = next
+        }
+        guard let node = current as? [String: Any] else { return false }
+        return isWallpaperNode(node)
+    }
+
+    /// Where to put a choice that `applyChoice` found no room for.
+    ///
+    /// This is issue #11's second half. A per-display apply matches on the
+    /// display's UUID, and a Mac that has never been given a different
+    /// wallpaper per screen has no node carrying that UUID at all: its one
+    /// wallpaper lives in `AllSpacesAndDisplays`. The old fallback invented
+    /// `Displays/<uuid>` for it, which is a node macOS does not read while
+    /// that shared node exists, so the apply wrote a file nothing rendered and
+    /// then read its own writing back as success.
+    ///
+    /// So prefer the shared nodes the store already has, and keep inventing a
+    /// per-display node only for a store that has neither. Writing the shared
+    /// node cannot take a wallpaper away from another display: this is only
+    /// reached when no per-display node matched, and a display that has its
+    /// own node is served by that node rather than this one.
+    public static func fallbackNodePaths(in store: Any, targetKey: String) -> [[String]] {
+        if targetKey == "all" { return [["AllSpacesAndDisplays"]] }
+        let shared = sharedNodePaths.filter { hasNode(at: $0, in: store) }
+        return shared.isEmpty ? [["Displays", targetKey]] : shared
+    }
+
+    /// Whether a surface at `surfacePath` belongs to the display being applied
+    /// to, or removed from.
+    ///
+    /// A shared node is everybody's. It is where a Mac with no per-display
+    /// node keeps its one wallpaper, so a per-display apply has to write it
+    /// and a per-display remove has to be able to take it back out again.
+    /// Without this second half the fallback above would leave a wallpaper
+    /// that nothing in the app could remove.
+    public static func surfaceBelongsToTarget(_ surfacePath: [String], targetKey: String) -> Bool {
+        if targetKey == "all" { return true }
+        if surfacePath.contains(targetKey) { return true }
+        return sharedNodePaths.contains { Array(surfacePath.dropLast()) == $0 }
+    }
+
+    /// Writes the choice at one path in the tree, whether or not a node is
+    /// already there.
+    ///
+    /// Replaces two helpers that each bolted a `Desktop` key onto whatever
+    /// they found and stamped `Type` as `individual` without adding the `Idle`
+    /// that word promises. That left nodes describing a shape they did not
+    /// have, and one reporter's Mac carried exactly that while macOS never
+    /// asked the extension for a single frame.
+    public static func ensureNode(
+        at path: [String],
+        choice: [String: Any],
+        desktopFallback: [String: Any],
+        idleFallback: [String: Any],
+        root: inout Any,
+        now: Date = Date()
+    ) {
+        guard let first = path.first, var rootDictionary = root as? [String: Any] else { return }
+        if path.count == 1 {
+            let existing = rootDictionary[first] as? [String: Any]
+            rootDictionary[first] = existing.map {
+                nodeApplying(
+                    choice: choice,
+                    to: $0,
+                    desktopFallback: desktopFallback,
+                    idleFallback: idleFallback,
+                    now: now
+                )
+            } ?? makeNode(
+                choice: choice,
+                desktopFallback: desktopFallback,
+                idleFallback: idleFallback,
+                now: now
+            )
+            root = rootDictionary
+            return
+        }
+        var container = rootDictionary[first] as? [String: Any] ?? [:]
+        var nested: Any = container
+        ensureNode(
+            at: Array(path.dropFirst()),
+            choice: choice,
+            desktopFallback: desktopFallback,
+            idleFallback: idleFallback,
+            root: &nested,
+            now: now
+        )
+        container = nested as? [String: Any] ?? container
+        rootDictionary[first] = container
+        root = rootDictionary
+    }
+
+    /// The whole write: put the choice in every node that already serves this
+    /// target, and when the tree has none, put it where that tree keeps its
+    /// wallpaper.
+    ///
+    /// Returns how many existing nodes were written, so a caller can still
+    /// tell a normal apply from one that had to fall back.
+    @discardableResult
+    public static func applyChoiceCreatingNode(
+        _ choice: [String: Any],
+        to store: inout Any,
+        targetKey: String,
+        desktopFallback: [String: Any],
+        idleFallback: [String: Any],
+        now: Date = Date()
+    ) -> Int {
+        let written = applyChoice(choice, to: &store, targetKey: targetKey, now: now)
+        guard written == 0 else { return written }
+        for path in fallbackNodePaths(in: store, targetKey: targetKey) {
+            ensureNode(
+                at: path,
+                choice: choice,
+                desktopFallback: desktopFallback,
+                idleFallback: idleFallback,
+                root: &store,
+                now: now
+            )
+        }
+        return written
+    }
+
     /// Puts the choice on one node, creating the surface key when the node
     /// does not have one yet.
     ///

--- a/Muro/Tests/MuroKitTests/AppleWallpaperStoreTests.swift
+++ b/Muro/Tests/MuroKitTests/AppleWallpaperStoreTests.swift
@@ -210,4 +210,169 @@ final class AppleWallpaperStoreTests: XCTestCase {
         XCTAssertEqual(choices?.count, 1)
         XCTAssertEqual(choices?.first?["Configuration"] as? Data, Data("two".utf8))
     }
+
+    // MARK: - kernelpanic-root, round two: the store with no node for his display
+
+    /// His `Index.plist`, rebuilt from the dump on the issue. One shared node
+    /// holding his wallpaper, and nothing carrying his display's UUID.
+    private var kernelpanicStore: Any {
+        [
+            "AllSpacesAndDisplays": ["Type": "linked", "Linked": surface(provider: "default")],
+            "SystemDefault": ["Type": "linked", "Linked": surface(provider: "default")],
+        ]
+    }
+
+    private let hisDisplay = "37D8832A-2D66-02CA-B9F7-8F30A301B230"
+
+    /// The failure itself: a per-display apply matches nothing, because the
+    /// tree has no node carrying his UUID.
+    func testPerDisplayApplyMatchesNothingOnHisStore() {
+        var store = kernelpanicStore
+        XCTAssertEqual(
+            AppleWallpaperStore.applyChoice(choice("abc"), to: &store, targetKey: hisDisplay),
+            0,
+            "nothing in his tree carries his display UUID"
+        )
+    }
+
+    /// And the fix: the choice goes to the node he actually has, not to an
+    /// invented per-display one macOS will not read.
+    func testFallbackWritesTheSharedNodeHeAlreadyHas() {
+        var store = kernelpanicStore
+        AppleWallpaperStore.applyChoiceCreatingNode(
+            choice("abc"),
+            to: &store,
+            targetKey: hisDisplay,
+            desktopFallback: surface(provider: "default"),
+            idleFallback: surface(provider: "default")
+        )
+
+        let root = store as? [String: Any]
+        XCTAssertNil(root?["Displays"], "no invented per-display node")
+        for name in ["AllSpacesAndDisplays", "SystemDefault"] {
+            let node = root?[name] as? [String: Any]
+            XCTAssertEqual(providers(node, "Linked"), [muro], "\(name) must hold it under Linked")
+            XCTAssertNil(node?["Desktop"], "\(name) is linked, a Desktop key is the old bug")
+            XCTAssertEqual(node?["Type"] as? String, "linked", "his own arrangement is not rewritten")
+            XCTAssertTrue(AppleWallpaperStore.isWellFormed(node ?? [:]))
+        }
+        XCTAssertTrue(AppleWallpaperStore.containsProvider(muro, in: store))
+    }
+
+    /// A Mac that does have a node for the display is untouched by any of
+    /// this: it matches, so the fallback never runs.
+    func testDisplayWithItsOwnNodeStillWinsAndSharedNodeIsLeftAlone() {
+        var store: Any = [
+            "AllSpacesAndDisplays": ["Type": "linked", "Linked": surface(provider: "aerials")],
+            "Displays": [hisDisplay: ["Type": "linked", "Linked": surface(provider: "aerials")]],
+        ]
+        let written = AppleWallpaperStore.applyChoiceCreatingNode(
+            choice("abc"),
+            to: &store,
+            targetKey: hisDisplay,
+            desktopFallback: surface(provider: "default"),
+            idleFallback: surface(provider: "default")
+        )
+
+        XCTAssertEqual(written, 1)
+        let root = store as? [String: Any]
+        let mine = (root?["Displays"] as? [String: Any])?[hisDisplay]
+        XCTAssertEqual(providers(mine, "Linked"), [muro])
+        XCTAssertEqual(
+            providers(root?["AllSpacesAndDisplays"], "Linked"),
+            ["aerials"],
+            "the shared node is not dragged along when the display has its own"
+        )
+    }
+
+    /// A tree with neither keeps the old behaviour rather than writing nothing.
+    func testStoreWithNoSharedNodeStillGetsAPerDisplayNode() {
+        var store: Any = ["Spaces": [String: Any]()]
+        AppleWallpaperStore.applyChoiceCreatingNode(
+            choice("abc"),
+            to: &store,
+            targetKey: hisDisplay,
+            desktopFallback: surface(provider: "default"),
+            idleFallback: surface(provider: "default")
+        )
+
+        let made = ((store as? [String: Any])?["Displays"] as? [String: Any])?[hisDisplay] as? [String: Any]
+        XCTAssertEqual(providers(made, "Desktop"), [muro])
+        XCTAssertTrue(AppleWallpaperStore.isWellFormed(made ?? [:]))
+    }
+
+    /// An all-displays apply is unchanged.
+    func testAllDisplaysFallbackIsStillTheAllDisplaysNode() {
+        XCTAssertEqual(
+            AppleWallpaperStore.fallbackNodePaths(in: kernelpanicStore, targetKey: "all"),
+            [["AllSpacesAndDisplays"]]
+        )
+    }
+
+    // MARK: - Removal has to reach the same node the apply wrote
+
+    /// Otherwise the fix above leaves a wallpaper the app cannot take off.
+    func testRemovingOneDisplayReachesTheSharedNodeItWrote() {
+        XCTAssertTrue(
+            AppleWallpaperStore.surfaceBelongsToTarget(["AllSpacesAndDisplays", "Linked"], targetKey: hisDisplay)
+        )
+        XCTAssertTrue(
+            AppleWallpaperStore.surfaceBelongsToTarget(["SystemDefault", "Linked"], targetKey: hisDisplay)
+        )
+    }
+
+    /// But it must not reach another display's own wallpaper.
+    func testRemovingOneDisplayLeavesAnotherDisplaysNodeAlone() {
+        XCTAssertFalse(
+            AppleWallpaperStore.surfaceBelongsToTarget(
+                ["Displays", "B7F3F6DA-9AA1-42F6-A1EF-B788BB495B27", "Linked"],
+                targetKey: hisDisplay
+            )
+        )
+        XCTAssertTrue(
+            AppleWallpaperStore.surfaceBelongsToTarget(["Displays", hisDisplay, "Linked"], targetKey: hisDisplay)
+        )
+        XCTAssertTrue(
+            AppleWallpaperStore.surfaceBelongsToTarget(["Displays", "anything", "Linked"], targetKey: "all")
+        )
+    }
+
+    /// A Space under the shared node is not the shared node.
+    func testSpacesUnderSharedNameAreNotTreatedAsShared() {
+        XCTAssertFalse(
+            AppleWallpaperStore.surfaceBelongsToTarget(
+                ["Spaces", "Default", "Displays", "OTHER", "Linked"],
+                targetKey: hisDisplay
+            )
+        )
+    }
+
+    /// The end of it, in the terms the issue is actually argued in.
+    ///
+    /// Muro's own diagnostics log prints, per store, the surface and node type
+    /// every Muro record sits on. His five applies all printed
+    /// `Index.plist=Desktop/individual`, which is the wallpaper sitting on a
+    /// key macOS does not read on his Mac. After the fix the same store prints
+    /// what a working System Settings apply printed on his machine.
+    func testHisDiagnosticLineNowReadsLinked() {
+        var store = kernelpanicStore
+        AppleWallpaperStore.applyChoiceCreatingNode(
+            choice("abc"),
+            to: &store,
+            targetKey: hisDisplay,
+            desktopFallback: surface(provider: "default"),
+            idleFallback: surface(provider: "default")
+        )
+
+        var seen: Set<String> = []
+        AppleWallpaperStore.forEachNode(in: store) { _, node in
+            for name in AppleWallpaperStore.surfaceNames {
+                guard let s = node[name] as? [String: Any],
+                      AppleWallpaperStore.providers(of: s).contains(muro)
+                else { continue }
+                seen.insert("\(name)/\(node["Type"] as? String ?? "none")")
+            }
+        }
+        XCTAssertEqual(seen.sorted().joined(separator: ","), "Linked/linked")
+    }
 }


### PR DESCRIPTION
macOS keeps its wallpaper in a list with one entry per screen, and Muro looks for the entry carrying the display it is applying to. A Mac that has never been given a different wallpaper per screen has no such entry at all: its one wallpaper lives in a shared entry instead. Muro matched nothing there, invented an entry of its own, and macOS went on reading the shared one. The lock screen kept showing Apple's wallpaper, and Muro read its own writing back as success, so it reported that the apply had worked.

That is why picking Muro by hand in System Settings worked on those Macs while applying it from inside Muro did not. System Settings writes the shared entry.

## What changed

Muro now writes the shared entry that store already has, under whichever key that entry uses, and only invents a per screen entry for a store that has neither. A Mac that does have an entry for the display matches first and is untouched, so nothing changes for the setups that already work.

Removal matched on the display in the same way, so once the apply could write the shared entry, Remove could no longer take it back off. Both halves now share one rule.

The node writer moves into MuroKit so this can be tested at all.

## How it was checked

None of this can be tried on the machine it was written on, which runs macOS 27 and has never held a store of that shape. So the shapes are rebuilt from the store a reporter pasted into the issue, and the assertions are the proof:

- a per screen apply on that store matches nothing, which is the failure
- after the fix the wallpaper lands in the shared entry, under `Linked`, with the entry's own type left alone
- a Mac that has its own entry for the display keeps winning, and its shared entry is not dragged along
- a store with neither still gets a per screen entry, so the old behaviour survives
- removing one display reaches the shared entry it wrote, and does not touch another display's
- the diagnostics line for that store now reads `Linked/linked` where it read `Desktop/individual`

135 tests pass.

## Still to confirm

The reporter's shape does not exist on any Mac available here, so this is proved against the dump he sent rather than by watching it work. His next dump should read `Linked/linked`.

Raised in #11