### PR TITLE
Keep the wallpaper on screen when Muro is hidden

### DIFF
--- a/Muro/Sources/MuroApp/Components.swift
+++ b/Muro/Sources/MuroApp/Components.swift
@@ -356,6 +356,19 @@ func window(titled title: String) -> NSWindow? {
     NSApp.windows.first { $0.title == title }
 }
 
+/// The two windows a person opens and closes: the gallery and Settings.
+///
+/// Named, rather than picked out by a property. The status item's own window
+/// answers to most of those, and ordering that one out takes the menu bar icon
+/// off the screen with it. The wallpaper is absent for its own reason: it says
+/// it cannot be hidden at all.
+@MainActor
+var muroDocumentWindows: [NSWindow] {
+    NSApp.orderedWindows.filter {
+        $0.title == MuroWindow.gallery || $0.title == MuroWindow.settings
+    }
+}
+
 /// The gallery window itself. `Window("Muro", id: "main")` is a SwiftUI scene,
 /// and closing it only orders it out, so it can always be brought back.
 @MainActor

--- a/Muro/Sources/MuroApp/MuroApp.swift
+++ b/Muro/Sources/MuroApp/MuroApp.swift
@@ -28,6 +28,7 @@ final class MuroAppDelegate: NSObject, NSApplicationDelegate {
         Self.applyActivationPolicy()
         engine.start()
         statusBar = StatusBarController(store: AppStore.shared)
+        watchForHideKey()
 
         // Starting at login is the Mac booting, not a person asking to see the
         // gallery. Muro used to throw its full window on screen every single
@@ -64,6 +65,42 @@ final class MuroAppDelegate: NSObject, NSApplicationDelegate {
     /// know the trick.
     func applicationDidBecomeActive(_ notification: Notification) {
         Self.applyActivationPolicy()
+    }
+
+    /// Command-H, when Muro has no menu bar to answer it.
+    ///
+    /// With the Dock icon off Muro is an accessory app, which has no menu bar,
+    /// so it has no Hide item and nothing responds to the key at all: AppKit
+    /// beeps. Hiding is an older habit than the Dock and the people who switch
+    /// the Dock icon off are exactly the people who use it.
+    ///
+    /// The windows are put away rather than the app being marked hidden. Waking
+    /// a hidden app is defined as putting every window it hid back on screen,
+    /// and opening the menu bar dropdown wakes the app, so a real hide came
+    /// straight back up with the dropdown. Windows that were simply ordered out
+    /// stay out until someone asks for them, which is always `showMainWindow`.
+    ///
+    /// With the Dock icon on this stands aside: there is a menu bar, and the
+    /// Hide item does the job properly, including bringing the windows back on
+    /// command-tab.
+    private func watchForHideKey() {
+        hideKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard NSApp.activationPolicy() == .accessory,
+                  event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                  event.charactersIgnoringModifiers?.lowercased() == "h"
+            else { return event }
+
+            MainActor.assumeIsolated {
+                for window in muroDocumentWindows where window.isVisible {
+                    window.orderOut(nil)
+                }
+            }
+            // Hiding hands the keyboard back to whatever was in front before,
+            // and an app left holding it with nothing on screen swallows the
+            // next thing typed.
+            NSApp.deactivate()
+            return nil
+        }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -153,6 +190,10 @@ final class MuroAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     fileprivate static let sessionEndedKey = "sessionEndedWithSystem"
+
+    /// Held for the life of the app. A local monitor is removed by handing this
+    /// token back, so losing it would leak the monitor.
+    private var hideKeyMonitor: Any?
 }
 
 /// Why the gallery did or did not appear at this launch. One line per start.

--- a/Muro/Sources/MuroKit/Engine/WallpaperWindowController.swift
+++ b/Muro/Sources/MuroKit/Engine/WallpaperWindowController.swift
@@ -67,6 +67,12 @@ public final class WallpaperWindowController {
         window.backgroundColor = .black
         window.hasShadow = false
         window.ignoresMouseEvents = true
+        // Hiding an app hides every window it owns, and the wallpaper is one
+        // of Muro's windows, so command-H took the desktop down with it and
+        // left the plain background showing. Hiding is meant to put an app's
+        // interface away, not to switch the wallpaper off, so this window opts
+        // out of it and keeps playing while the rest of Muro disappears.
+        window.canHide = false
         window.isReleasedWhenClosed = false
         window.animationBehavior = .none
 


### PR DESCRIPTION
## Summary

Hiding an app hides every window it owns, and Muro's wallpaper is a window, so command-H took the desktop down with it and left the plain background showing. The wallpaper window now says it cannot be hidden. The gallery goes away, the desktop keeps playing.

With **Show Dock icon** switched off there was nothing to hide with either. Muro is an accessory app in that mode, which has no menu bar, so it has no Hide item and nothing answered command-H at all. AppKit just beeped. Muro answers the key itself there.

It puts its windows away rather than letting macOS mark the app as hidden. Waking a hidden app puts every window it hid back on screen, and opening the menu bar dropdown wakes the app, so a real hide came straight back up with the dropdown. This way the dropdown opens on its own.

## Test plan

Tested with the Dock icon both on and off.

- [x] Command-H hides the gallery and the wallpaper keeps playing
- [x] Hide Others from another app does the same
- [x] Dock icon off: command-H works instead of beeping
- [x] Dock icon off: the menu bar dropdown opens without bringing the gallery with it
- [x] Open Muro in the dropdown still brings the gallery back
- [x] `swift test`, 135 passing

Raised in #21
