### PR TITLE
Muro can be the screen saver

### DIFF
--- a/Muro/Sources/MuroApp/Components.swift
+++ b/Muro/Sources/MuroApp/Components.swift
@@ -384,7 +384,24 @@ func showMainWindow() {
     // the window would be put away again in front of them.
     GalleryLaunchSuppressor.shared.stop()
     NSApp.activate(ignoringOtherApps: true)
-    mainWindow?.makeKeyAndOrderFront(nil)
+
+    // The window does not always exist yet. SwiftUI builds a `Window` scene's
+    // `NSWindow` the first time that window is actually shown, and a Mac
+    // started with Muro set to launch at login never shows it, so on that
+    // launch there was nothing here to bring forward and this did nothing at
+    // all. Reported after a restart: the menu bar opened, Open Muro did
+    // nothing, and opening Muro some other way fixed it for the rest of the
+    // session. Asking SwiftUI for the window by its id is the only thing that
+    // can create one.
+    guard let window = mainWindow else {
+        WindowOpener.shared.gallery?()
+        // It arrives on a later pass of the event loop, so taking the
+        // keyboard has to wait for it. `openWindow` has already put it in
+        // front, this is only insurance.
+        DispatchQueue.main.async { mainWindow?.makeKeyAndOrderFront(nil) }
+        return
+    }
+    window.makeKeyAndOrderFront(nil)
 }
 
 /// Make a window's yellow button put it away rather than minimise it.
@@ -506,18 +523,37 @@ func openWhatsNew(_ store: AppStore) {
 
 @MainActor
 func openSettingsWindow() {
-    // Environment openWindow isn't reachable from plain helpers; the
-    // Settings scene registers this callback at launch. Activate first —
-    // when called from the (non-activating) menu bar panel the app isn't
-    // active and the window would open behind others.
+    // Environment openWindow is not reachable from plain helpers, so the app
+    // registers it at launch. Activate first: called from the menu bar panel,
+    // which never activates the app, the window would open behind everything
+    // else.
     NSApp.activate(ignoringOtherApps: true)
-    SettingsWindowOpener.shared.open?()
+    WindowOpener.shared.settings?()
 }
 
+/// SwiftUI's `openWindow`, kept somewhere AppKit code can reach it.
+///
+/// Both closures are registered by the `App` itself while Muro starts, and
+/// that is the whole point of this type. Settings used to be registered in the
+/// gallery window's `onAppear`, which only runs once that window has been
+/// shown. A Mac restarted with Muro launching at login never shows it, so both
+/// menu bar rows were dead until Muro was opened some other way: Open Muro had
+/// no window to bring forward, and Settings had no way to ask for one.
 @MainActor
-final class SettingsWindowOpener {
-    static let shared = SettingsWindowOpener()
-    var open: (() -> Void)?
+final class WindowOpener {
+    static let shared = WindowOpener()
+
+    var gallery: (() -> Void)?
+    var settings: (() -> Void)?
+
+    /// Called from the `App`'s body, which is evaluated while the app starts
+    /// whether or not any window is ever put on screen. Re-registering is
+    /// harmless, and the body is evaluated again whenever SwiftUI feels like
+    /// it.
+    func install(gallery: @escaping () -> Void, settings: @escaping () -> Void) {
+        self.gallery = gallery
+        self.settings = settings
+    }
 }
 
 // MARK: - Styled dropdown menus

--- a/Muro/Sources/MuroApp/ConfirmDeleteView.swift
+++ b/Muro/Sources/MuroApp/ConfirmDeleteView.swift
@@ -207,6 +207,7 @@ struct ConfirmDeleteView: View {
         var out: [String] = []
         if let playing = playingNotice { out.append(playing) }
         if lockScreenAffected { out.append("LOCK SCREEN") }
+        if screenSaverAffected { out.append("SCREEN SAVER") }
         return out
     }
 
@@ -228,6 +229,11 @@ struct ConfirmDeleteView: View {
     private var lockScreenAffected: Bool {
         guard let lockID = store.lockScreenWallpaperID else { return false }
         return items.contains { $0.id == lockID }
+    }
+
+    private var screenSaverAffected: Bool {
+        guard let saverID = store.screenSaverWallpaperID else { return false }
+        return items.contains { $0.id == saverID }
     }
 
     private func friendly(_ display: DisplayInfo) -> String {

--- a/Muro/Sources/MuroApp/DesktopStillService.swift
+++ b/Muro/Sources/MuroApp/DesktopStillService.swift
@@ -120,6 +120,9 @@ final class DesktopStillService {
         var missing: [(id: String, video: URL)] = []
         var stillForExtension: URL?
         var anyWallpaper = false
+        // One entry per display, so the extension can draw each screen's own
+        // wallpaper rather than the main display's on all of them.
+        var perDisplay: [CGDirectDisplayID: URL] = [:]
 
         for screen in NSScreen.screens {
             guard let uuid = displayUUID(for: screen) else { continue }
@@ -142,13 +145,14 @@ final class DesktopStillService {
             if stillForExtension == nil || screen == NSScreen.screens.first {
                 stillForExtension = still
             }
+            if let id = directDisplayID(for: screen) { perDisplay[id] = still }
             set(still, on: screen, uuid: uuid, isLockScreenOwned: lockScreenDisplays.contains(uuid))
         }
 
-        // The extension draws one picture for the whole Mac, so it is given
-        // the main display's. Muro's own window is per screen and still shows
-        // the right video everywhere; this is only the frozen fallback for
-        // when Muro is not running.
+        // One picture per display, plus the main display's as the fallback for
+        // a surface macOS names no display for. Muro's own window is per screen
+        // and shows the right video everywhere while it is running; this is the
+        // frozen fallback for when it is not.
         //
         // Nothing is taken away while a still is only late. The first time a
         // wallpaper is applied its still has to be decoded out of the video,
@@ -157,7 +161,9 @@ final class DesktopStillService {
         // out from under the desktop for as long as the decode took. Clearing
         // is for a Mac with no Muro wallpaper at all.
         if stillForExtension != nil || !anyWallpaper {
-            LockScreenService.publishDesktopStill(stillForExtension)
+            LockScreenService.publishDesktopStills(
+                perDisplay: perDisplay, main: stillForExtension
+            )
         }
         return missing
     }

--- a/Muro/Sources/MuroApp/LockScreenService.swift
+++ b/Muro/Sources/MuroApp/LockScreenService.swift
@@ -71,7 +71,27 @@ final class LockScreenService {
     private static let removedSelection = "__none__"
 
     private struct SelectionState: Codable {
-        var selections: [String: String] = [:] // "all" or display UUID -> wallpaper ID
+        /// "all" or display UUID -> wallpaper ID, for the desktop role, which
+        /// is what the lock screen renders.
+        var selections: [String: String] = [:]
+        /// The same, for the screen saver.
+        var screenSaver: [String: String] = [:]
+
+        init() {}
+
+        /// Written by hand so a state file from a build that had no screen
+        /// saver still decodes. The synthesised initialiser throws on the
+        /// missing key, and this file is loaded with `try?`, so that would
+        /// have quietly thrown away somebody's lock screen selection.
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            selections = try container.decodeIfPresent(
+                [String: String].self, forKey: .selections
+            ) ?? [:]
+            screenSaver = try container.decodeIfPresent(
+                [String: String].self, forKey: .screenSaver
+            ) ?? [:]
+        }
     }
 
     private struct ExtensionEntry: Codable {
@@ -216,21 +236,72 @@ final class LockScreenService {
             && FileManager.default.fileExists(atPath: extensionBundleURL.path)
     }
 
+    /// macOS keeps **one screen saver for the whole Mac**, so a per-display
+    /// screen saver does not exist to write.
+    ///
+    /// This is what made the first attempt look like it had done nothing. The
+    /// wallpaper store keeps the screen saver in a node called
+    /// `AllSpacesAndDisplays`, typed `idle`, which is the screen saver and
+    /// nothing else. A per-display apply matches on the display's UUID, that
+    /// node carries no UUID, so every per-display node got Muro and the one
+    /// node macOS actually reads kept saying `default`. System Settings went
+    /// on showing Apple's own screen saver and there was nothing in the store
+    /// to suggest anything was wrong.
+    ///
+    /// Apple's own interface has no per-display screen saver picker either,
+    /// and macOS asks this extension for the same wallpaper once per screen
+    /// when it starts, which is the same fact seen from the other side.
+    static func storeTargetKey(_ targetKey: String, for surface: AppleWallpaperStore.Surface) -> String {
+        surface == .screenSaver ? "all" : targetKey
+    }
+
+    /// The selections for one role. Both live in the same file and share one
+    /// staged library, so a wallpaper on the lock screen and the screen saver
+    /// at once is staged once and stored once.
+    private static func selections(
+        _ state: SelectionState, for surface: AppleWallpaperStore.Surface
+    ) -> [String: String] {
+        surface == .screenSaver ? state.screenSaver : state.selections
+    }
+
+    private static func setSelections(
+        _ value: [String: String],
+        for surface: AppleWallpaperStore.Surface,
+        in state: inout SelectionState
+    ) {
+        if surface == .screenSaver { state.screenSaver = value } else { state.selections = value }
+    }
+
+    /// Every wallpaper either role is holding. What has to stay staged.
+    private static func heldIDs(_ state: SelectionState) -> Set<String> {
+        Set(state.selections.values)
+            .union(state.screenSaver.values)
+            .subtracting([removedSelection])
+    }
+
     var activeWallpaperIDs: Set<String> {
-        Set(state.selections.values.filter { $0 != Self.removedSelection })
+        Self.heldIDs(state)
     }
     var activeWallpaperID: String? {
         state.selections["all"]
             ?? state.selections.values.first(where: { $0 != Self.removedSelection })
     }
 
+    var screenSaverWallpaperID: String? {
+        state.screenSaver["all"]
+            ?? state.screenSaver.values.first(where: { $0 != Self.removedSelection })
+    }
+
     /// The targets whose lock screen currently shows one of `ids`. A delete
     /// clears exactly those, rather than wiping the lock screen on every
     /// display because one of them happened to hold a wallpaper going away.
-    func targets(showing ids: Set<String>) -> [ApplyTarget] {
-        state.selections
+    func targets(
+        showing ids: Set<String>,
+        surface: AppleWallpaperStore.Surface = .desktop
+    ) -> [ApplyTarget] {
+        Self.selections(state, for: surface)
             .filter { $0.value != Self.removedSelection && ids.contains($0.value) }
-            .map { $0.key == "all" ? .all : .display($0.key) }
+            .map { $0.key == "all" || surface == .screenSaver ? .all : .display($0.key) }
     }
 
     /// True when Muro's lock screen is sitting on this display's macOS
@@ -242,21 +313,37 @@ final class LockScreenService {
     /// `NSWorkspace.desktopImageURL`, which does not reliably name an
     /// extension as the owner.
     func ownsWallpaperSurface(displayUUID: String) -> Bool {
+        // The lock screen role only. The screen saver lives on `Idle`, which
+        // is not the key the desktop still is written to, so it is not this
+        // question. The one Mac where it would be is a linked one, where macOS
+        // keeps both on `Linked`; that is a known limit rather than a guess
+        // made here, because changing this rule changes the desktop, and the
+        // desktop is not what the screen saver was asked to touch.
         let effective = state.selections[displayUUID] ?? state.selections["all"]
         guard let effective, effective != Self.removedSelection else { return false }
         return true
     }
 
-    func isApplied(wallpaperID: String, target: ApplyTarget) -> Bool {
+    func isApplied(
+        wallpaperID: String,
+        target: ApplyTarget,
+        surface: AppleWallpaperStore.Surface = .desktop
+    ) -> Bool {
+        let selections = Self.selections(state, for: surface)
+        // One screen saver for the Mac: asking about a single display is the
+        // same question as asking about all of them.
+        if surface == .screenSaver {
+            return selections["all"] == wallpaperID
+        }
         switch target {
         case .all:
-            guard state.selections["all"] == wallpaperID else { return false }
-            return state.selections
+            guard selections["all"] == wallpaperID else { return false }
+            return selections
                 .filter { $0.key != "all" }
                 .values
                 .allSatisfy { $0 == wallpaperID }
         case .display(let uuid):
-            let effective = state.selections[uuid] ?? state.selections["all"]
+            let effective = selections[uuid] ?? selections["all"]
             return effective == wallpaperID
         }
     }
@@ -316,18 +403,19 @@ final class LockScreenService {
         entry: WallpaperEntry,
         videoURL: URL,
         thumbnailURL: URL,
-        target: ApplyTarget
+        target: ApplyTarget,
+        surface: AppleWallpaperStore.Surface = .desktop
     ) async throws -> LockScreenApplyOutcome {
         try validateAvailability()
-        let targetKey = Self.targetKey(target)
+        let targetKey = Self.storeTargetKey(Self.targetKey(target), for: surface)
         let previousState = state
         var nextState = state
-        // One lock-screen wallpaper at a time, whatever it was applied to.
+        // One wallpaper per role at a time, whatever it was applied to.
         // Every staged wallpaper appears as its own row in System Settings, so
         // keeping a selection per display grew that list a row at a time and
         // the extra rows read as leftovers nobody could clear. Picking a new
         // one now replaces the old one rather than joining it.
-        nextState.selections = [targetKey: entry.id]
+        Self.setSelections([targetKey: entry.id], for: surface, in: &nextState)
 
         let extensionURL = extensionBundleURL
         let root = root
@@ -356,6 +444,7 @@ final class LockScreenService {
                         wallpaperID: entry.id,
                         videoURL: Self.stagedVideoURL(id: entry.id),
                         targetKey: targetKey,
+                        surface: surface,
                         root: root
                     )
                     Self.notifyLibraryChanged()
@@ -376,9 +465,7 @@ final class LockScreenService {
                 }
 
                 try Self.saveState(nextState, root: root)
-                try Self.pruneStagedLibrary(
-                    keeping: Set(nextState.selections.values).subtracting([Self.removedSelection])
-                )
+                try Self.pruneStagedLibrary(keeping: Self.heldIDs(nextState))
                 let settled = acknowledged || storeHolds
                 // The wallpaper this one replaced has just lost its staged
                 // file, so every record still naming it is now dead. Sweeping
@@ -415,8 +502,8 @@ final class LockScreenService {
                 }
                 Self.restartWallpaperAgent()
                 try? Self.saveState(previousState, root: root)
-                try? Self.pruneStagedLibrary(keeping: Set(previousState.selections.values))
-                if previousState.selections.isEmpty {
+                try? Self.pruneStagedLibrary(keeping: Self.heldIDs(previousState))
+                if Self.heldIDs(previousState).isEmpty {
                     Self.unregisterExtension(at: extensionURL)
                     try? FileManager.default.removeItem(at: Self.backupDirectoryURL(root: root))
                     try? FileManager.default.removeItem(at: Self.legacyBackupURL(root: root))
@@ -436,27 +523,33 @@ final class LockScreenService {
         return outcome
     }
 
-    func remove(target: ApplyTarget) async throws {
-        let targetKey = Self.targetKey(target)
+    func remove(
+        target: ApplyTarget,
+        surface: AppleWallpaperStore.Surface = .desktop
+    ) async throws {
+        let targetKey = Self.storeTargetKey(Self.targetKey(target), for: surface)
         var nextState = state
+        var selections = Self.selections(nextState, for: surface)
         if targetKey == "all" {
-            nextState.selections.removeAll()
-        } else if nextState.selections["all"] != nil {
+            selections.removeAll()
+        } else if selections["all"] != nil {
             // An explicit empty override lets one display opt out while the
             // all-displays fallback remains active everywhere else.
-            nextState.selections[targetKey] = Self.removedSelection
+            selections[targetKey] = Self.removedSelection
         } else {
-            nextState.selections[targetKey] = nil
+            selections[targetKey] = nil
         }
+        Self.setSelections(selections, for: surface, in: &nextState)
         let root = root
         let extensionURL = extensionBundleURL
+        let stateAfter = nextState
         try await Task.detached(priority: .userInitiated) {
-            try await Self.restoreWallpaperStores(targetKey: targetKey, root: root)
-            try Self.saveState(nextState, root: root)
-            Self.restartWallpaperAgent()
-            try Self.pruneStagedLibrary(
-                keeping: Set(nextState.selections.values).subtracting([Self.removedSelection])
+            try await Self.restoreWallpaperStores(
+                targetKey: targetKey, surface: surface, root: root
             )
+            try Self.saveState(stateAfter, root: root)
+            Self.restartWallpaperAgent()
+            try Self.pruneStagedLibrary(keeping: Self.heldIDs(stateAfter))
             // `restoreWallpaperStores` only rewrites surfaces matching this
             // target. Records for the same wallpaper under a display that is
             // no longer connected, or under another Space, are not matched and
@@ -464,7 +557,10 @@ final class LockScreenService {
             if (try? Self.purgeDeadMuroSurfaces(root: root)) == true {
                 Self.restartWallpaperAgent()
             }
-            if nextState.selections.values.allSatisfy({ $0 == Self.removedSelection }) {
+            // Only once neither role is holding anything. Unregistering while
+            // the screen saver is still Muro would take the screen saver away
+            // with the lock screen.
+            if Self.heldIDs(stateAfter).isEmpty {
                 Self.unregisterExtension(at: extensionURL)
                 try? FileManager.default.removeItem(at: Self.backupDirectoryURL(root: root))
                 try? FileManager.default.removeItem(at: Self.legacyBackupURL(root: root))
@@ -807,6 +903,7 @@ final class LockScreenService {
         wallpaperID: String,
         videoURL: URL,
         targetKey: String,
+        surface: AppleWallpaperStore.Surface,
         root: URL
     ) async throws {
         let manager = FileManager.default
@@ -853,6 +950,7 @@ final class LockScreenService {
                 choice,
                 to: &store,
                 targetKey: targetKey,
+                surface: surface,
                 desktopFallback: firstNonMuroSurface(named: "Desktop", in: store) ?? defaultSurface(),
                 idleFallback: firstNonMuroSurface(named: "Idle", in: store) ?? defaultSurface()
             )
@@ -866,8 +964,27 @@ final class LockScreenService {
         }
     }
 
+    /// The store keys one role occupies, and the only ones a removal of that
+    /// role may hand back.
+    ///
+    /// `Linked` is in both lists on purpose. It is the one key that carries
+    /// the desktop and the screen saver together, which is what linking them
+    /// means, so neither can be taken off it without the other. Nothing else
+    /// overlaps: removing a lock screen wallpaper leaves a Muro screen saver
+    /// exactly where it was.
+    private static func surfaceNames(
+        for role: AppleWallpaperStore.Surface?
+    ) -> [String] {
+        switch role {
+        case .desktop: return ["Desktop", "Linked"]
+        case .screenSaver: return ["Idle", "Linked"]
+        case nil: return AppleWallpaperStore.surfaceNames
+        }
+    }
+
     private static func restoreWallpaperStores(
         targetKey: String,
+        surface role: AppleWallpaperStore.Surface? = nil,
         root: URL
     ) async throws {
         let manager = FileManager.default
@@ -879,10 +996,11 @@ final class LockScreenService {
                 try? PropertyListSerialization.propertyList(from: $0, format: nil)
             }
 
-            // Desktop is what we now own; Idle/Linked are cleaned too so any
-            // records left by older builds (or a manual System Settings click)
-            // are also stripped and the user's own wallpaper comes back.
-            for surfaceName in ["Desktop", "Idle", "Linked"] {
+            // Only the keys this role occupies. Passing no role sweeps all
+            // three, which is what a full clear and the launch heal want: they
+            // are also what strips records left by older builds, or by a
+            // manual System Settings click.
+            for surfaceName in surfaceNames(for: role) {
                 let fallback = backup.flatMap { firstNonMuroSurface(named: surfaceName, in: $0) }
                     ?? firstNonMuroSurface(named: surfaceName, in: current)
                     ?? crossStoreNonMuroSurface(named: surfaceName)

--- a/Muro/Sources/MuroApp/LockScreenService.swift
+++ b/Muro/Sources/MuroApp/LockScreenService.swift
@@ -193,6 +193,26 @@ final class LockScreenService {
             _ = await Task.detached(priority: .utility) {
                 (try? Self.purgeDeadMuroSurfaces(root: root)) == true
             }.value
+            // Muro being *somewhere* in the stores is what got us into this
+            // branch, and that is not the same as Muro holding everything it
+            // claims. The desktop and the lock screen can be perfectly healthy
+            // while the screen saver has been handed to Apple's aerials, which
+            // is what an update installed over a running Muro does. Nothing
+            // used to notice, so it stayed Apple's until the user applied a
+            // screen saver again by hand.
+            let currentState = self.state
+            let repaired = await Task.detached(priority: .utility) {
+                await Self.repairScreenSaverIfMissing(currentState, root: root)
+            }.value
+            if repaired {
+                // Only reached when the screen saver really was wrong, so this
+                // is the case the comment above calls worth the restart: the
+                // agent is holding a resolution that does not match the store.
+                // `reviveExtensionIfNeeded` below waits for the extension to
+                // answer, so the gap it opens is closed before anyone can see
+                // the desktop.
+                await Task.detached(priority: .utility) { Self.restartWallpaperAgent() }.value
+            }
             await Self.reviveExtensionIfNeeded()
             return
         }
@@ -458,16 +478,25 @@ final class LockScreenService {
                         wallpaperID: entry.id, since: applyStart, timeout: 3
                     ) {
                         acknowledged = true
+                    }
+                    // **A receipt is no longer enough on its own, and neither
+                    // is "Muro is in one of the files".** Both were true on the
+                    // owner's Mac on 2026-09-10 while `Index.plist`, the file
+                    // macOS reads, had the screen saver back on Apple's
+                    // default. The loop broke on the first pass with two passes
+                    // in hand and the screen saver played Apple's aerial
+                    // wallpaper. Ask the question that matters: does **every**
+                    // store hold **this role**, for **this target**.
+                    if Self.storesMissingRole(targetKey: targetKey, surface: surface).isEmpty {
                         storeHolds = true
                         break
                     }
-                    // No receipt. If the stores still hold the choice then
-                    // macOS simply has not come looking, and writing it a
-                    // fourth time will not make it. Only a choice the agent
-                    // overwrote is worth another pass.
-                    storeHolds = Self.wallpaperStoresHaveSelection()
-                    if storeHolds { break }
                 }
+                // Three passes and a store still refuses it. The verdict below
+                // stays exactly as loose as it has always been, so nothing that
+                // used to report success starts telling the user to go to
+                // System Settings; only the retrying got stricter.
+                if !storeHolds { storeHolds = Self.wallpaperStoresHaveSelection() }
 
                 try Self.saveState(nextState, root: root)
                 try Self.pruneStagedLibrary(keeping: Self.heldIDs(nextState))
@@ -694,6 +723,78 @@ final class LockScreenService {
                 extensionBundleID, in: loadWallpaperStore(at: $0)
             )
         }
+    }
+
+    /// The store files that are **not** holding this role right now.
+    ///
+    /// `wallpaperStoresHaveSelection` above is deliberately loose: it answers
+    /// "is Muro anywhere at all", and `healIfNeeded` needs exactly that,
+    /// because the branch it guards tears everything down. It must not be
+    /// tightened.
+    ///
+    /// An apply needs the opposite. Muro writes two store files, and on
+    /// 2026-09-10 the owner's Mac finished an apply with the screen saver held
+    /// by Muro in `Index2.plist` and by Apple's default in `Index.plist`. macOS
+    /// reads `Index.plist`, so the screen saver played Apple's aerial
+    /// wallpaper, which is the "Tahoe wallpaper" report. The loose check saw
+    /// Muro in the other file, called the apply settled and broke out of a
+    /// retry loop that existed for this exact case and had two passes left.
+    ///
+    /// Empty means every file holds it. Anything else is a pass worth making.
+    private static func storesMissingRole(
+        targetKey: String,
+        surface: AppleWallpaperStore.Surface
+    ) -> [URL] {
+        wallpaperStoreURLs.filter { url in
+            !AppleWallpaperStore.holdsRole(
+                extensionBundleID,
+                in: loadWallpaperStore(at: url),
+                targetKey: targetKey,
+                surface: surface
+            )
+        }
+    }
+
+    /// Puts back a role Muro's own record claims but Apple's stores no longer
+    /// hold, without staging anything or touching the record.
+    ///
+    /// **Scoped to the screen saver on purpose.** That is the role that was
+    /// observed being taken away, and it is the simple one: it is always
+    /// `all`, so there is no per-display node to reason about. The lock screen
+    /// is per connected display, is confirmed working on two displays, and
+    /// `healIfNeeded` has no display list to check against, so a repair there
+    /// would rewrite a display that is merely unplugged. It is left alone.
+    ///
+    /// **How the screen saver goes missing.** Replacing `/Applications/Muro.app`
+    /// while Muro is running makes macOS log "Wallpaper extension was removed",
+    /// and WallpaperAgent then hands the screen saver to Apple's aerials and
+    /// writes that into the store. Measured on the owner's Mac on 2026-09-10:
+    /// the bundle was replaced at 18:33:49 and by 18:34:10 the aerials
+    /// extension had been launched and the store saved. Muro's desktop and
+    /// lock screen come back on relaunch because they are re-applied; the
+    /// screen saver had nothing that noticed. That is every user who updates
+    /// Muro while it is open, not only a build machine.
+    private static func repairScreenSaverIfMissing(
+        _ state: SelectionState, root: URL
+    ) async -> Bool {
+        guard let id = state.screenSaver[LockScreenSelections.allKey],
+              id != removedSelection
+        else { return false }
+        let video = stagedVideoURL(id: id)
+        // No staged file means the wallpaper is genuinely gone, and rewriting
+        // the store would only point macOS at nothing.
+        guard FileManager.default.fileExists(atPath: video.path) else { return false }
+        guard !storesMissingRole(targetKey: "all", surface: .screenSaver).isEmpty else {
+            return false
+        }
+        try? await updateWallpaperStores(
+            wallpaperID: id,
+            videoURL: video,
+            targetKey: "all",
+            surface: .screenSaver,
+            root: root
+        )
+        return true
     }
 
 

--- a/Muro/Sources/MuroApp/LockScreenService.swift
+++ b/Muro/Sources/MuroApp/LockScreenService.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import MuroKit
 
@@ -166,14 +167,33 @@ final class LockScreenService {
         }.value
         // A healthy selection can still sit alongside records left by earlier
         // wallpapers, so this path sweeps rather than simply returning.
+        //
+        // **It sweeps without restarting WallpaperAgent, and that is the whole
+        // point of this branch.** Killing the agent takes every wallpaper off
+        // the screen until macOS resolves them again, and that is not
+        // instant: measured at **58 seconds** on the owner's Mac on
+        // 2026-09-10. During it macOS draws its own default picture, because
+        // the provider it has a record for is not running. While Muro is open
+        // nobody sees that, its own windows are over the top. Quit inside that
+        // window and the desktops are Apple's default, which is exactly the
+        // "second quit gives me Tahoe" report: the first quit is clean, the
+        // reopen sweeps and kills the agent, and the quit after it lands in
+        // the gap. Locking the Mac ends it early, because that makes macOS
+        // resolve the wallpaper again, which is why locking and unlocking
+        // always looked like the cure.
+        //
+        // Nothing here is worth that. The sweep is bookkeeping: it corrects
+        // records for wallpapers that are already gone, while a healthy
+        // selection is being served by a running extension. Writing the store
+        // is enough, macOS reads it when it next resolves, and the wallpaper
+        // on screen never goes anywhere. The unhealthy path below still
+        // restarts the agent, because there the wallpaper is already wrong and
+        // getting it looked at again is the fix rather than the cost.
         guard !stillSelected else {
-            let collapsed = collapseToOneSelection()
-            let changed = await Task.detached(priority: .utility) {
+            _ = await Task.detached(priority: .utility) {
                 (try? Self.purgeDeadMuroSurfaces(root: root)) == true
             }.value
-            if changed || collapsed {
-                await Task.detached(priority: .utility) { Self.restartWallpaperAgent() }.value
-            }
+            await Self.reviveExtensionIfNeeded()
             return
         }
 
@@ -189,47 +209,22 @@ final class LockScreenService {
         state = SelectionState()
     }
 
-    /// Older builds kept a lock-screen selection per display, so a Mac with
-    /// two screens ended up with two staged wallpapers and two rows in System
-    /// Settings that read as leftovers nobody could clear. One at a time is
-    /// the rule now; this brings an install that predates it into line, once.
-    ///
-    /// The one kept is whatever Apple's store is pointing at, because that is
-    /// the wallpaper actually on screen. Only the others lose their staged
-    /// files, and `purgeDeadMuroSurfaces` hands their records back to the
-    /// user's own wallpaper.
-    private func collapseToOneSelection() -> Bool {
-        let ids = Set(state.selections.values.filter { $0 != Self.removedSelection })
-        guard ids.count > 1 else { return false }
-        guard let keep = Self.storeWallpaperID().flatMap({ ids.contains($0) ? $0 : nil })
-            ?? activeWallpaperID
-        else { return false }
-        state.selections = ["all": keep]
-        try? Self.saveState(state, root: root)
-        try? Self.pruneStagedLibrary(keeping: [keep])
-        return true
-    }
-
-    /// The Muro wallpaper Apple's own store is pointing at right now.
-    private static func storeWallpaperID() -> String? {
-        for url in wallpaperStoreURLs {
-            guard let store = loadWallpaperStore(at: url) else { continue }
-            var found: String?
-            AppleWallpaperStore.forEachNode(in: store) { _, node in
-                guard found == nil else { return }
-                for name in AppleWallpaperStore.surfaceNames {
-                    guard let surface = node[name] as? [String: Any],
-                          isMuroSurface(surface),
-                          let id = muroWallpaperID(of: surface), !id.isEmpty
-                    else { continue }
-                    found = id
-                    return
-                }
-            }
-            if let found { return found }
-        }
-        return nil
-    }
+    // `collapseToOneSelection` was here, with the one helper it used. It
+    // enforced an older rule, one lock screen for the whole Mac, and it ran on
+    // every launch. Once a lock screen per display became the rule, this is
+    // what it did, measured on the owner's Mac on 2026-09-10 with a MacBook
+    // and a DELL: he set a lock screen on each, both worked, he quit and
+    // reopened Muro, and on that launch it saw two, kept whichever one Apple's
+    // store happened to name, and threw the other away. The discarded
+    // wallpaper's staged video went with it, `purgeDeadMuroSurfaces` then
+    // handed that display's slot back to a plain picture, and the screen saver
+    // died as well because it pruned to the single lock screen id and forgot
+    // `state.screenSaver` existed. Three symptoms, one function.
+    //
+    // What it guarded against is real and is handled elsewhere now: every
+    // staged wallpaper is a row in System Settings, and
+    // `LockScreenSelections.afterApply` bounds the record at one per connected
+    // display plus `all`, so the rows cannot pile up.
 
     var isAvailable: Bool {
         ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26
@@ -805,40 +800,69 @@ final class LockScreenService {
     ///
     /// Nothing is created for somebody who has never used the lock screen: if
     /// the extension has no container yet there is nothing to hand it.
-    static func publishDesktopStill(_ url: URL?) {
+    /// Hand the extension the picture **each display's** desktop is set to.
+    ///
+    /// One file per display, named with the same `CGDirectDisplayID` macOS
+    /// puts in the acquire request, plus the unnumbered file as the fallback
+    /// for a surface that names no display. This used to publish a single
+    /// picture, the main display's, and hand it to every surface, so on a Mac
+    /// with two screens the second one showed the first one's wallpaper once
+    /// Muro quit. That reads as the two having swapped (owner, 2026-09-10).
+    ///
+    /// Files for displays that are no longer plugged in are removed, so the
+    /// container cannot grow a picture per monitor ever owned.
+    static func publishDesktopStills(perDisplay: [CGDirectDisplayID: URL], main: URL?) {
         let manager = FileManager.default
         let documents = extensionDocumentsURL
         guard manager.fileExists(atPath: documents.path) else { return }
-        let image = documents.appendingPathComponent("desktop-still.jpg")
-        // The source path doubles as the record of what is already staged, so
-        // a playlist stepping through wallpapers it has shown before does not
-        // recopy a 4K frame on every step.
-        let marker = documents.appendingPathComponent("desktop-still.source")
+
+        var wanted = Set<String>()
+        for (displayID, url) in perDisplay {
+            let name = "desktop-still-\(displayID).jpg"
+            wanted.insert(name)
+            stageStill(url, named: name, in: documents)
+        }
+        if let names = try? manager.contentsOfDirectory(atPath: documents.path) {
+            for name in names
+            where name.hasPrefix("desktop-still-") && name.hasSuffix(".jpg")
+                && !wanted.contains(name) {
+                try? manager.removeItem(at: documents.appendingPathComponent(name))
+                try? manager.removeItem(at: documents.appendingPathComponent(name + ".source"))
+            }
+        }
+        stageStill(main, named: "desktop-still.jpg", in: documents)
+        notifyDesktopStillChanged()
+    }
+
+    /// The whole-Mac form, for the caller that is clearing everything.
+    static func publishDesktopStill(_ url: URL?) {
+        publishDesktopStills(perDisplay: [:], main: url)
+    }
+
+    /// Puts one picture in the extension's container under `name`.
+    ///
+    /// Nothing is copied when the same source is already staged: the app asks
+    /// for this again on every apply and every playlist step, and that would
+    /// be a 4K JPEG copied each time. The source path written beside the file
+    /// is the record of what is already there.
+    private static func stageStill(_ url: URL?, named name: String, in documents: URL) {
+        let manager = FileManager.default
+        let image = documents.appendingPathComponent(name)
+        let marker = documents.appendingPathComponent(name + ".source")
         let staged = try? String(contentsOf: marker, encoding: .utf8)
 
         guard let url else {
-            guard staged != nil || manager.fileExists(atPath: image.path) else { return }
             try? manager.removeItem(at: image)
             try? manager.removeItem(at: marker)
-            notifyDesktopStillChanged()
             return
         }
-
-        // Already the picture that is staged. Nothing is copied, but the
-        // extension is still told, because this is also how Muro puts a
-        // desktop right that came up wrong: opening Muro has to fix it at
-        // once rather than whenever the wallpaper next happens to change.
-        // The extension decodes the file only when it is a different one.
-        guard staged != url.path || !manager.fileExists(atPath: image.path) else {
-            notifyDesktopStillChanged()
-            return
-        }
+        guard staged != url.path || !manager.fileExists(atPath: image.path) else { return }
         // Copied beside it and moved into place, never written through. The
         // extension decodes this file whenever it is told the preferences
         // changed, and the app posts that same notification for other reasons,
-        // so a plain copy left a window in which the picture on the desktop
-        // was being read out of a half written file.
-        let incoming = documents.appendingPathComponent("desktop-still.incoming.jpg")
+        // so a plain copy left a window in which the picture on the desktop was
+        // being read out of a half written file.
+        let incoming = documents.appendingPathComponent(name + ".incoming")
         try? manager.removeItem(at: incoming)
         guard (try? manager.copyItem(at: url, to: incoming)) != nil else { return }
         do {
@@ -852,7 +876,6 @@ final class LockScreenService {
             return
         }
         try? url.path.write(to: marker, atomically: true, encoding: .utf8)
-        notifyDesktopStillChanged()
     }
 
     /// Ask the extension to draw the desktop's picture again, without staging
@@ -1216,6 +1239,55 @@ final class LockScreenService {
     /// `pluginkit -a` exits 0 even when it rejects the bundle, so its status
     /// says nothing. The registry is the only honest answer: register, then
     /// wait for the extension to actually appear in it.
+    /// Make sure the wallpaper extension is alive before Muro settles in.
+    ///
+    /// **Why this is here at all.** The extension is the only thing drawing
+    /// the desktop once Muro's own windows are gone, and launching Muro is
+    /// what takes it away. Measured twice on the owner's Mac, from macOS's own
+    /// log, within a second of the app starting:
+    ///
+    ///     extension-proxy: interruptionHandler called for com.mrrockysl.muro…
+    ///     extension-proxy: invalidationHandler called for com.mrrockysl.muro…
+    ///     extension-proxy: ERROR - connect: com.apple.extensionKit.errorDomain (2)
+    ///
+    /// macOS drops the extension, tries to reconnect once, fails, and then
+    /// leaves it. It came back on its own after 27 seconds in one run and 58
+    /// in another, and until it does macOS draws its own default picture,
+    /// because the provider its store names is not running.
+    ///
+    /// Nobody sees that while Muro is open, its windows are over the top.
+    /// **Quit inside the gap and both desktops are Apple's default**, and that
+    /// is the whole of the "the second quit gives me Tahoe" report: the first
+    /// quit is clean, the reopen drops the extension, and the quit after it
+    /// lands in the gap. Locking the Mac ends it early because that makes
+    /// macOS resolve the wallpaper again, which is why locking and unlocking
+    /// always looked like the cure.
+    ///
+    /// So the gap is closed here, at launch, where it costs nothing and no
+    /// one can be looking at the desktop yet. macOS is given two seconds to
+    /// reconnect on its own first, because usually it does and a restart is
+    /// the heavier thing.
+    private static func reviveExtensionIfNeeded() async {
+        for _ in 0..<8 {
+            if extensionIsRunning() { return }
+            try? await Task.sleep(nanoseconds: 250_000_000)
+        }
+        restartWallpaperAgent()
+        for _ in 0..<24 {
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            if extensionIsRunning() { return }
+        }
+    }
+
+    /// Whether the extension process is up. Muro is not sandboxed, and this is
+    /// the only honest answer: `pluginkit` reports registration, which stays
+    /// true for an extension macOS has just thrown away.
+    static func extensionIsRunning() -> Bool {
+        !runCapturing("/usr/bin/pgrep", ["-f", "MuroWallpaperExtension.appex"])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+    }
+
     private static func registerExtension(at url: URL) async throws {
         clearQuarantine()
         _ = run("/usr/bin/pluginkit", ["-a", url.path])

--- a/Muro/Sources/MuroApp/LockScreenService.swift
+++ b/Muro/Sources/MuroApp/LockScreenService.swift
@@ -404,18 +404,28 @@ final class LockScreenService {
         videoURL: URL,
         thumbnailURL: URL,
         target: ApplyTarget,
-        surface: AppleWallpaperStore.Surface = .desktop
+        surface: AppleWallpaperStore.Surface = .desktop,
+        connectedDisplays: Set<String> = []
     ) async throws -> LockScreenApplyOutcome {
         try validateAvailability()
         let targetKey = Self.storeTargetKey(Self.targetKey(target), for: surface)
         let previousState = state
         var nextState = state
-        // One wallpaper per role at a time, whatever it was applied to.
-        // Every staged wallpaper appears as its own row in System Settings, so
-        // keeping a selection per display grew that list a row at a time and
-        // the extra rows read as leftovers nobody could clear. Picking a new
-        // one now replaces the old one rather than joining it.
-        Self.setSelections([targetKey: entry.id], for: surface, in: &nextState)
+        // One per connected display, not one for the whole Mac. This used to
+        // be `[targetKey: entry.id]`, which threw away every other display's
+        // lock screen on each apply. See LockScreenSelections for what that
+        // cost and why it was written that way. A screen saver apply always
+        // carries "all", so this is the same record it always was for it.
+        Self.setSelections(
+            LockScreenSelections.afterApply(
+                current: Self.selections(nextState, for: surface),
+                targetKey: targetKey,
+                wallpaperID: entry.id,
+                connectedDisplays: connectedDisplays
+            ),
+            for: surface,
+            in: &nextState
+        )
 
         let extensionURL = extensionBundleURL
         let root = root

--- a/Muro/Sources/MuroApp/MuroApp.swift
+++ b/Muro/Sources/MuroApp/MuroApp.swift
@@ -239,13 +239,20 @@ struct MuroApp: App {
     @Environment(\.openWindow) private var openWindow
 
     var body: some Scene {
+        // Registered here rather than in a window's `onAppear`, because this
+        // body is evaluated while Muro starts whether or not a window is ever
+        // shown, and a launch at login never shows one. See `WindowOpener`.
+        let _ = WindowOpener.shared.install(
+            gallery: { openWindow(id: "main") },
+            settings: { openWindow(id: "settings") }
+        )
+
         Window(MuroWindow.gallery, id: "main") {
             RootView()
                 .environmentObject(store)
                 .frame(minWidth: 1180, minHeight: 760)
                 .preferredColorScheme(.dark)
                 .onAppear {
-                    SettingsWindowOpener.shared.open = { openWindow(id: "settings") }
                     // Here rather than in the delegate: the window is what is
                     // being reconfigured, and by the time its content appears
                     // it definitely exists. Re-applied on every appearance, so

--- a/Muro/Sources/MuroApp/PreviewView.swift
+++ b/Muro/Sources/MuroApp/PreviewView.swift
@@ -397,6 +397,26 @@ struct PreviewView: View {
 /// card is what actually applies the wallpaper; displays already showing
 /// it get a green dot. Works with any number of connected displays.
 struct ChooseDisplayPopover: View {
+    /// Every button in this popover is exactly this size: the cards in the
+    /// grid, a lone display's card, and the screen saver's All Screens card.
+    /// They used to be three different widths, and an applied card grew taller
+    /// than an unapplied one because a Remove pill is bigger than a line of
+    /// grey text, so the whole popover moved when you applied a wallpaper
+    /// (owner, 2026-09-10: "all the display buttons have to be the same size,
+    /// 100% the same size").
+    static let cardWidth: CGFloat = 148
+    static let cardHeight: CGFloat = 88
+    static let cardGap: CGFloat = 10
+    /// Two cards across is what sets the card's width, and the tab row has to
+    /// fit inside the same space. Measured with the real font at 11.5
+    /// semibold: the four labels are 288pt of text and padding at 11, plus
+    /// three gaps, against the 310pt these cards leave. See the tab row.
+    static let pillPadding: CGFloat = 11
+    static let pillGap: CGFloat = 3
+    /// One animation for the whole popover, so the tab pill, the crossfade and
+    /// a card turning green all move together instead of at three speeds.
+    static let ease = Animation.spring(response: 0.34, dampingFraction: 0.86)
+
     @EnvironmentObject var store: AppStore
     let item: WallpaperItem
     @Namespace private var surfaceNS
@@ -407,18 +427,18 @@ struct ChooseDisplayPopover: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // 3 and 11 below, not 4 and 14, because this row is what decides
-            // how wide the popover has to be and nothing else comes close.
-            // Measured with the real font: 324pt at 14, 297pt at 11, so the
-            // card could come in from 400 to 340 (owner, 2026-09-10: "reduce
-            // the length of the card and increase the height a little bit").
-            HStack(spacing: 3) {
-                Spacer()
+            // No Spacers. A `Spacer` carries a default minimum length of its
+            // own, and two of them plus the extra gaps added 22pt to a row
+            // that had 13pt of room, which is what wrapped "Lockscreen" onto
+            // two lines. The row centres itself against the card's width
+            // instead, and every label is pinned to one line so this can never
+            // be a silent wrap again.
+            HStack(spacing: Self.pillGap) {
                 ForEach(ApplySurface.allCases, id: \.self) { surface in
                     surfacePill(surface)
                 }
-                Spacer()
             }
+            .frame(maxWidth: .infinity)
             // The chooser stays laid out underneath so it keeps defining the
             // width and height. The popover must never resize: it is anchored
             // at the bottom, so a change of height moves the top edge and the
@@ -462,7 +482,7 @@ struct ChooseDisplayPopover: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             Button {
-                withAnimation(.easeOut(duration: 0.18)) { showLockRequirement = false }
+                withAnimation(Self.ease) { showLockRequirement = false }
             } label: {
                 Text("Set my desktop instead")
                     .font(.system(size: 11.5, weight: .semibold))
@@ -511,33 +531,38 @@ struct ChooseDisplayPopover: View {
                     .allowsHitTesting(!isScreenSaver)
                 if isScreenSaver { screenSaverCard.transition(.opacity) }
             }
+            .animation(Self.ease, value: isScreenSaver)
+            .animation(Self.ease, value: store.currentAppliedID)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// One card per connected display, for the surfaces that can really be set
     /// per display.
-    @ViewBuilder private var displayChooser: some View {
-        // One display has no second column to sit beside, so the grid left it
-        // hard against the edge with the popover's whole width empty next to
-        // it. On its own it is centred instead, and kept to about the width it
-        // would have had in the grid so it does not stretch into a banner.
-        if store.displays.count == 1, let only = store.displays.first {
-            HStack(spacing: 0) {
-                Spacer(minLength: 0)
-                displayCard(only).frame(maxWidth: 165)
-                Spacer(minLength: 0)
-            }
-        } else {
-            LazyVGrid(
-                columns: [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)],
-                spacing: 10
-            ) {
-                ForEach(store.displays) { display in
-                    displayCard(display)
+    ///
+    /// Rows of two, each row centred on the card, rather than a two column
+    /// grid. A grid stretches its columns to whatever width it is given, which
+    /// is what made a lone display's card a different size from a pair of
+    /// them, and it leaves an odd last card hard against the left edge. Rows
+    /// of fixed cards look the same at one display, at two, and at three,
+    /// where the popover simply grows a row taller.
+    private var displayRows: [[DisplayInfo]] {
+        stride(from: 0, to: store.displays.count, by: 2).map { start in
+            Array(store.displays[start..<min(start + 2, store.displays.count)])
+        }
+    }
+
+    private var displayChooser: some View {
+        VStack(spacing: Self.cardGap) {
+            ForEach(Array(displayRows.enumerated()), id: \.offset) { _, row in
+                HStack(spacing: Self.cardGap) {
+                    ForEach(row) { display in
+                        displayCard(display)
+                    }
                 }
             }
         }
+        .frame(maxWidth: .infinity)
     }
 
     /// One card, never one per screen.
@@ -551,8 +576,7 @@ struct ChooseDisplayPopover: View {
     /// button, for a single setting (owner, 2026-09-10).
     private var screenSaverCard: some View {
         let applied = store.isApplied(item, surface: .screensaver, target: .all)
-        return HStack(spacing: 0) {
-            Spacer(minLength: 0)
+        return Group {
             Button {
                 if applied {
                     store.removeWallpaper(item, target: .all, surface: .screensaver)
@@ -568,14 +592,13 @@ struct ChooseDisplayPopover: View {
                 )
             }
             .buttonStyle(.plain)
-            .frame(maxWidth: 165)
             .accessibilityLabel(
                 applied
                     ? "Remove \(item.title) from the screen saver"
                     : "Apply \(item.title) to the screen saver"
             )
-            Spacer(minLength: 0)
         }
+        .frame(maxWidth: .infinity)
     }
 
     /// The card chrome both choosers draw.
@@ -592,9 +615,9 @@ struct ChooseDisplayPopover: View {
         sublabel: String,
         applied: Bool
     ) -> some View {
-        VStack(spacing: 7) {
+        VStack(spacing: 6) {
             Image(systemName: symbol)
-                .font(.system(size: 22))
+                .font(.system(size: 21))
                 .foregroundStyle(.white.opacity(0.9))
             HStack(spacing: 5) {
                 if applied {
@@ -604,7 +627,9 @@ struct ChooseDisplayPopover: View {
                     .font(.system(size: 11.5, weight: .semibold))
                     .foregroundStyle(.white)
                     .lineLimit(1)
+                    .minimumScaleFactor(0.85)
             }
+            .padding(.horizontal, 8)
             if applied {
                 Text("Remove")
                     .font(.system(size: 10, weight: .semibold))
@@ -619,8 +644,10 @@ struct ChooseDisplayPopover: View {
                     .foregroundStyle(Color.muroSecondary)
             }
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 15)
+        // Fixed, not `maxWidth: .infinity` with padding. That is the whole of
+        // "the same size": the frame is the card, and what is inside it can
+        // change without the card changing.
+        .frame(width: Self.cardWidth, height: Self.cardHeight)
         .background(RoundedRectangle(cornerRadius: 16, style: .continuous)
             .fill(.glassSheen(0.12, 0.05)))
         .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -651,18 +678,20 @@ struct ChooseDisplayPopover: View {
             guard enabled else {
                 // Not disabled any more. A dead button tells someone their
                 // click failed; this tells them what the rule is.
-                withAnimation(.easeOut(duration: 0.18)) { showLockRequirement = true }
+                withAnimation(Self.ease) { showLockRequirement = true }
                 return
             }
-            withAnimation(.easeOut(duration: 0.18)) {
+            withAnimation(Self.ease) {
                 showLockRequirement = false
                 store.applySurface = surface
             }
         } label: {
             Text(surface.rawValue)
                 .font(.system(size: 11.5, weight: .semibold))
+                .lineLimit(1)
+                .fixedSize()
                 .foregroundStyle(selected ? Color.black : Color.white.opacity(enabled ? 0.8 : 0.3))
-                .padding(.horizontal, 11)
+                .padding(.horizontal, Self.pillPadding)
                 .padding(.vertical, 6)
                 .background {
                     if selected {

--- a/Muro/Sources/MuroApp/PreviewView.swift
+++ b/Muro/Sources/MuroApp/PreviewView.swift
@@ -153,7 +153,7 @@ struct PreviewView: View {
                 // A popover paints its own square grey sheet behind whatever
                 // it is given, which is what made this the one panel in the
                 // app that was a flat dark box (owner, 2026-08-24).
-                .anchoredCard(isPresented: $showDisplayPopover, width: 330, align: .trailing) {
+                .anchoredCard(isPresented: $showDisplayPopover, width: 400, align: .trailing) {
                     ChooseDisplayPopover(item: item)
                         .environmentObject(store)
                 }
@@ -445,11 +445,11 @@ struct ChooseDisplayPopover: View {
             }
             .frame(width: 40, height: 40)
 
-            Text("Lock screen needs macOS 26")
+            Text("This needs macOS 26")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(.white)
 
-            Text("Live lock screen wallpapers use a part of macOS that arrived in macOS 26. This Mac runs \(Self.osLabel), so Muro can set your desktop but not your lock screen.")
+            Text("The lock screen and the screen saver use a part of macOS that arrived in macOS 26. This Mac runs \(Self.osLabel), so Muro can set your desktop but not those.")
                 .font(.system(size: 11.5, weight: .medium))
                 .foregroundStyle(Color.muroSecondary)
                 .multilineTextAlignment(.center)
@@ -484,11 +484,19 @@ struct ChooseDisplayPopover: View {
     private var chooser: some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack {
-                Text("Choose display")
-                    .font(.system(size: 11.5, weight: .medium))
-                    .foregroundStyle(Color.muroSecondary)
+                // The screen saver is one setting for the whole Mac, so there
+                // is no display to choose. Saying so is better than a picker
+                // whose choice does not matter, and better than hiding the
+                // card people are used to clicking.
+                Text(
+                    store.applySurface == .screensaver
+                        ? "Every display"
+                        : "Choose display"
+                )
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(Color.muroSecondary)
                 Spacer()
-                if store.displays.count > 1 { allPill }
+                if store.displays.count > 1, store.applySurface != .screensaver { allPill }
             }
             // One display has no second column to sit beside, so the grid
             // left it hard against the edge with the popover's whole width
@@ -528,7 +536,7 @@ struct ChooseDisplayPopover: View {
 
     private func surfacePill(_ surface: ApplySurface) -> some View {
         let selected = store.applySurface == surface
-        let enabled = surface == .desktop || store.lockScreenAvailable
+        let enabled = !surface.needsAppleExtension || store.lockScreenAvailable
         // Constant font weight: weight changes used to resize the labels and
         // make "Lockscreen" jump sideways when switching Both → Desktop.
         return Button {
@@ -571,7 +579,7 @@ struct ChooseDisplayPopover: View {
         .buttonStyle(.plain)
         .accessibilityLabel("Apply to \(surface.rawValue.lowercased())")
         .accessibilityValue(selected ? "Selected" : "Not selected")
-        .help(enabled ? "" : "Lock-screen live wallpapers require macOS 26 or later")
+        .help(enabled ? "" : "The lock screen and screen saver require macOS 26 or later")
     }
 
     private var allPill: some View {
@@ -583,7 +591,7 @@ struct ChooseDisplayPopover: View {
                 apply(.all)
             }
         } label: {
-            Text(appliedEverywhere ? "Remove All" : "All")
+            Text(appliedEverywhere ? "Remove all" : "All displays")
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(appliedEverywhere ? Color(hex: 0xFF6B6B) : .white)
                 .padding(.horizontal, 13)

--- a/Muro/Sources/MuroApp/PreviewView.swift
+++ b/Muro/Sources/MuroApp/PreviewView.swift
@@ -406,7 +406,7 @@ struct ChooseDisplayPopover: View {
     @State private var showLockRequirement = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 4) {
                 Spacer()
                 ForEach(ApplySurface.allCases, id: \.self) { surface in
@@ -427,7 +427,7 @@ struct ChooseDisplayPopover: View {
                 }
             }
         }
-        .padding(18)
+        .padding(15)
         // No background of its own: `anchoredCard` draws it on the same glass
         // as every dropdown, with the same corner radius.
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -482,45 +482,148 @@ struct ChooseDisplayPopover: View {
     }
 
     private var chooser: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        let isScreenSaver = store.applySurface == .screensaver
+        return VStack(alignment: .leading, spacing: 11) {
             HStack {
                 // The screen saver is one setting for the whole Mac, so there
                 // is no display to choose. Saying so is better than a picker
                 // whose choice does not matter, and better than hiding the
                 // card people are used to clicking.
-                Text(
-                    store.applySurface == .screensaver
-                        ? "Every display"
-                        : "Choose display"
-                )
-                .font(.system(size: 11.5, weight: .medium))
-                .foregroundStyle(Color.muroSecondary)
+                Text(isScreenSaver ? "Every display" : "Choose display")
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundStyle(Color.muroSecondary)
                 Spacer()
-                if store.displays.count > 1, store.applySurface != .screensaver { allPill }
+                if store.displays.count > 1, !isScreenSaver { allPill }
             }
-            // One display has no second column to sit beside, so the grid
-            // left it hard against the edge with the popover's whole width
-            // empty next to it. On its own it is centred instead, and kept to
-            // about the width it would have had in the grid so it does not
-            // stretch into a banner.
-            if store.displays.count == 1, let only = store.displays.first {
-                HStack(spacing: 0) {
-                    Spacer(minLength: 0)
-                    displayCard(only).frame(maxWidth: 200)
-                    Spacer(minLength: 0)
-                }
-            } else {
-                LazyVGrid(
-                    columns: [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)],
-                    spacing: 10
-                ) {
-                    ForEach(store.displays) { display in
-                        displayCard(display)
-                    }
-                }
+            // The per-display chooser stays laid out underneath on the screen
+            // saver tab as well, so it goes on defining the height. The popover
+            // is anchored at its bottom edge, so a tab shorter than the others
+            // would move the top edge and the whole card would jump on every
+            // switch (owner, 2026-07-20).
+            ZStack {
+                displayChooser
+                    .opacity(isScreenSaver ? 0 : 1)
+                    .allowsHitTesting(!isScreenSaver)
+                if isScreenSaver { screenSaverCard.transition(.opacity) }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// One card per connected display, for the surfaces that can really be set
+    /// per display.
+    @ViewBuilder private var displayChooser: some View {
+        // One display has no second column to sit beside, so the grid left it
+        // hard against the edge with the popover's whole width empty next to
+        // it. On its own it is centred instead, and kept to about the width it
+        // would have had in the grid so it does not stretch into a banner.
+        if store.displays.count == 1, let only = store.displays.first {
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+                displayCard(only).frame(maxWidth: 200)
+                Spacer(minLength: 0)
+            }
+        } else {
+            LazyVGrid(
+                columns: [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)],
+                spacing: 10
+            ) {
+                ForEach(store.displays) { display in
+                    displayCard(display)
+                }
+            }
+        }
+    }
+
+    /// One card, never one per screen.
+    ///
+    /// A screen saver is a single setting for the whole Mac. macOS keeps it in
+    /// `AllSpacesAndDisplays`, a node that carries no display name at all, and
+    /// Apple's own settings have no per-display screen saver picker either.
+    /// `LockScreenService.storeTargetKey` already forces every screen saver
+    /// apply to "all", so a card per display was offering a choice that does
+    /// not exist: one click lit every card green and gave each its own Remove
+    /// button, for a single setting (owner, 2026-09-10).
+    private var screenSaverCard: some View {
+        let applied = store.isApplied(item, surface: .screensaver, target: .all)
+        return HStack(spacing: 0) {
+            Spacer(minLength: 0)
+            Button {
+                if applied {
+                    store.removeWallpaper(item, target: .all, surface: .screensaver)
+                } else {
+                    apply(.all)
+                }
+            } label: {
+                cardLabel(
+                    symbol: "display.2",
+                    name: "All Screens",
+                    sublabel: "Every display",
+                    applied: applied
+                )
+            }
+            .buttonStyle(.plain)
+            .frame(maxWidth: 200)
+            .accessibilityLabel(
+                applied
+                    ? "Remove \(item.title) from the screen saver"
+                    : "Apply \(item.title) to the screen saver"
+            )
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// The card chrome both choosers draw.
+    ///
+    /// The shape belongs to the button's label, not to the button. Hung
+    /// outside it, the frame, padding and background drew a card while the
+    /// button itself stayed the size of the icon and the name, so most of the
+    /// card looked clickable and was not. A `contentShape` outside a button
+    /// cannot fix that either: it shapes the view it is attached to, not the
+    /// button's own hit region.
+    private func cardLabel(
+        symbol: String,
+        name: String,
+        sublabel: String,
+        applied: Bool
+    ) -> some View {
+        VStack(spacing: 5) {
+            Image(systemName: symbol)
+                .font(.system(size: 19))
+                .foregroundStyle(.white.opacity(0.9))
+            HStack(spacing: 5) {
+                if applied {
+                    Circle().fill(Color.muroGreen).frame(width: 5, height: 5)
+                }
+                Text(name)
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+            }
+            if applied {
+                Text("Remove")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color(hex: 0xFF6B6B))
+                    .padding(.horizontal, 11)
+                    .padding(.vertical, 3)
+                    .background(Capsule().fill(Color(hex: 0xFF6B6B).opacity(0.13)))
+                    .overlay(Capsule().strokeBorder(Color(hex: 0xFF6B6B).opacity(0.4), lineWidth: 1))
+            } else {
+                Text(sublabel)
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color.muroSecondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 11)
+        .background(RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .fill(.glassSheen(0.12, 0.05)))
+        .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .strokeBorder(
+                applied ? Color.muroGreen.opacity(0.55) : Color.white.opacity(0.14),
+                lineWidth: applied ? 1.5 : 1
+            ))
+        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 
     /// Applies without dismissing — people with several displays apply to
@@ -629,50 +732,12 @@ struct ChooseDisplayPopover: View {
                 apply(.display(display.id))
             }
         } label: {
-            VStack(spacing: 6) {
-                Image(systemName: display.symbolName)
-                    .font(.system(size: 20))
-                    .foregroundStyle(.white.opacity(0.9))
-                HStack(spacing: 5) {
-                    if appliedHere {
-                        Circle().fill(Color.muroGreen).frame(width: 5, height: 5)
-                    }
-                    Text(display.displayName)
-                        .font(.system(size: 11.5, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .lineLimit(1)
-                }
-                if appliedHere {
-                    Text("Remove")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(Color(hex: 0xFF6B6B))
-                        .padding(.horizontal, 11)
-                        .padding(.vertical, 3.5)
-                        .background(Capsule().fill(Color(hex: 0xFF6B6B).opacity(0.13)))
-                        .overlay(Capsule().strokeBorder(Color(hex: 0xFF6B6B).opacity(0.4), lineWidth: 1))
-                } else {
-                    Text(display.kindLabel)
-                        .font(.system(size: 10))
-                        .foregroundStyle(Color.muroSecondary)
-                }
-            }
-            // The card's shape belongs to the button's label, not to the
-            // button. Hung outside it, the frame, padding and background drew
-            // a card while the button itself stayed the size of the icon and
-            // the name, so most of the card looked clickable and was not.
-            // A `contentShape` outside a button cannot fix that either: it
-            // shapes the view it is attached to, not the button's own hit
-            // region.
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 13)
-            .background(RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(.glassSheen(0.12, 0.05)))
-            .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .strokeBorder(
-                    appliedHere ? Color.muroGreen.opacity(0.55) : Color.white.opacity(0.14),
-                    lineWidth: appliedHere ? 1.5 : 1
-                ))
-            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            cardLabel(
+                symbol: display.symbolName,
+                name: display.displayName,
+                sublabel: display.kindLabel,
+                applied: appliedHere
+            )
         }
         .buttonStyle(.plain)
         .accessibilityLabel(

--- a/Muro/Sources/MuroApp/PreviewView.swift
+++ b/Muro/Sources/MuroApp/PreviewView.swift
@@ -153,7 +153,7 @@ struct PreviewView: View {
                 // A popover paints its own square grey sheet behind whatever
                 // it is given, which is what made this the one panel in the
                 // app that was a flat dark box (owner, 2026-08-24).
-                .anchoredCard(isPresented: $showDisplayPopover, width: 400, align: .trailing) {
+                .anchoredCard(isPresented: $showDisplayPopover, width: 340, align: .trailing) {
                     ChooseDisplayPopover(item: item)
                         .environmentObject(store)
                 }
@@ -407,7 +407,12 @@ struct ChooseDisplayPopover: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 4) {
+            // 3 and 11 below, not 4 and 14, because this row is what decides
+            // how wide the popover has to be and nothing else comes close.
+            // Measured with the real font: 324pt at 14, 297pt at 11, so the
+            // card could come in from 400 to 340 (owner, 2026-09-10: "reduce
+            // the length of the card and increase the height a little bit").
+            HStack(spacing: 3) {
                 Spacer()
                 ForEach(ApplySurface.allCases, id: \.self) { surface in
                     surfacePill(surface)
@@ -520,7 +525,7 @@ struct ChooseDisplayPopover: View {
         if store.displays.count == 1, let only = store.displays.first {
             HStack(spacing: 0) {
                 Spacer(minLength: 0)
-                displayCard(only).frame(maxWidth: 200)
+                displayCard(only).frame(maxWidth: 165)
                 Spacer(minLength: 0)
             }
         } else {
@@ -563,7 +568,7 @@ struct ChooseDisplayPopover: View {
                 )
             }
             .buttonStyle(.plain)
-            .frame(maxWidth: 200)
+            .frame(maxWidth: 165)
             .accessibilityLabel(
                 applied
                     ? "Remove \(item.title) from the screen saver"
@@ -587,9 +592,9 @@ struct ChooseDisplayPopover: View {
         sublabel: String,
         applied: Bool
     ) -> some View {
-        VStack(spacing: 5) {
+        VStack(spacing: 7) {
             Image(systemName: symbol)
-                .font(.system(size: 19))
+                .font(.system(size: 22))
                 .foregroundStyle(.white.opacity(0.9))
             HStack(spacing: 5) {
                 if applied {
@@ -615,7 +620,7 @@ struct ChooseDisplayPopover: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 11)
+        .padding(.vertical, 15)
         .background(RoundedRectangle(cornerRadius: 16, style: .continuous)
             .fill(.glassSheen(0.12, 0.05)))
         .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -657,7 +662,7 @@ struct ChooseDisplayPopover: View {
             Text(surface.rawValue)
                 .font(.system(size: 11.5, weight: .semibold))
                 .foregroundStyle(selected ? Color.black : Color.white.opacity(enabled ? 0.8 : 0.3))
-                .padding(.horizontal, 14)
+                .padding(.horizontal, 11)
                 .padding(.vertical, 6)
                 .background {
                     if selected {

--- a/Muro/Sources/MuroApp/SettingsView.swift
+++ b/Muro/Sources/MuroApp/SettingsView.swift
@@ -16,6 +16,10 @@ struct SettingsView: View {
     /// Apple's preference rather than stored here and re-read whenever this
     /// window comes forward: System Settings can change it behind our back.
     @State private var screenSaverDelay = ScreenSaverDelay.current()
+    /// Set the moment the delay is changed, cleared when the window is next
+    /// brought forward. It is the only place the user is told that macOS does
+    /// not pick a new delay up straight away.
+    @State private var screenSaverDelayJustChanged = false
     /// The window keeps this view alive across close/reopen, which used to
     /// preserve the scroll position — reopening must always show the header.
     @State private var scrollToTopOnNextOpen = false
@@ -150,7 +154,10 @@ struct SettingsView: View {
                                 MenuOption(
                                     title: ScreenSaverDelay.label(seconds),
                                     checked: screenSaverDelay == seconds
-                                ) { screenSaverDelay = ScreenSaverDelay.set(seconds) }
+                                ) {
+                                    screenSaverDelay = ScreenSaverDelay.set(seconds)
+                                    screenSaverDelayJustChanged = true
+                                }
                             }
                         }) {
                             HStack(spacing: 6) {
@@ -282,6 +289,7 @@ struct SettingsView: View {
             )) { note in
                 guard (note.object as? NSWindow)?.title == MuroWindow.settings else { return }
                 screenSaverDelay = ScreenSaverDelay.current()
+                screenSaverDelayJustChanged = false
             }
             }
         }
@@ -315,6 +323,20 @@ struct SettingsView: View {
     /// there is no system-wide plist to read it from and loginwindow does not
     /// publish the number it falls back to.
     private var screenSaverSubtitle: String {
+        // Said once, right after a change, because it is the moment it matters
+        // and it is the difference between "this is broken" and "this is how
+        // macOS works". Measured on the owner's Mac on 2026-09-10: the delay
+        // was set to 10 minutes at 18:36:51, macOS read it and armed a timer
+        // for the full 600 seconds, and did not look at the setting again
+        // until 18:46:51. Two further changes in between were ignored. This is
+        // not Muro: `loginwindow` reads the preference only when its own timer
+        // fires or when the screen is locked, and there is no notification,
+        // XPC message or public API that makes it look sooner. Apple's own
+        // Settings panel writes the same key the same way and behaves
+        // identically.
+        if screenSaverDelayJustChanged {
+            return "Saved. macOS uses it after the current wait ends, or now if you lock the screen."
+        }
         guard let seconds = screenSaverDelay else {
             return "macOS is deciding. Pick a time to set it."
         }

--- a/Muro/Sources/MuroApp/SettingsView.swift
+++ b/Muro/Sources/MuroApp/SettingsView.swift
@@ -12,6 +12,10 @@ struct SettingsView: View {
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var confirmClear = false
     @State private var customPauseAfter = false
+    /// macOS's own screen saver delay, not a Muro setting, so it is read from
+    /// Apple's preference rather than stored here and re-read whenever this
+    /// window comes forward: System Settings can change it behind our back.
+    @State private var screenSaverDelay = ScreenSaverDelay.current()
     /// The window keeps this view alive across close/reopen, which used to
     /// preserve the scroll position — reopening must always show the header.
     @State private var scrollToTopOnNextOpen = false
@@ -132,6 +136,36 @@ struct SettingsView: View {
                             )) { customPauseAfter = false }
                         }
                     }
+                    divider
+                    // Apple's setting, offered here so a Mac running Muro as
+                    // its screen saver never needs System Settings opened for
+                    // the one number that decides when it runs. Muro writes
+                    // the same key Apple's own panel writes, and loginwindow
+                    // picks it up at its next idle check with nothing to
+                    // restart. See MuroKit/ScreenSaverDelay.swift.
+                    row(icon: "sparkles.tv", tint: .cyan, title: "Start Screen Saver",
+                        subtitle: screenSaverSubtitle) {
+                        GlassDropdown(width: 150, align: .trailing, options: {
+                            ScreenSaverDelay.choices.map { seconds in
+                                MenuOption(
+                                    title: ScreenSaverDelay.label(seconds),
+                                    checked: screenSaverDelay == seconds
+                                ) { screenSaverDelay = ScreenSaverDelay.set(seconds) }
+                            }
+                        }) {
+                            HStack(spacing: 6) {
+                                Text(ScreenSaverDelay.label(screenSaverDelay))
+                                    .font(.system(size: 12, weight: .semibold))
+                                    .foregroundStyle(.white)
+                                Image(systemName: "chevron.down")
+                                    .font(.system(size: 8, weight: .semibold))
+                                    .foregroundStyle(.white.opacity(0.6))
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 5.5)
+                            .glassCapsule(fill: 0.09, stroke: 0.15)
+                        }
+                    }
                 }
 
                 section("ENERGY") {
@@ -238,6 +272,17 @@ struct SettingsView: View {
                 scrollToTopOnNextOpen = false
                 proxy.scrollTo("settings-top", anchor: .top)
             }
+            // Separate from the scroll handler above on purpose: that one only
+            // runs on a reopen, and this has to run every time the window is
+            // brought forward, including straight after a trip to System
+            // Settings, or the row would keep showing a value macOS no longer
+            // holds.
+            .onReceive(NotificationCenter.default.publisher(
+                for: NSWindow.didBecomeKeyNotification
+            )) { note in
+                guard (note.object as? NSWindow)?.title == MuroWindow.settings else { return }
+                screenSaverDelay = ScreenSaverDelay.current()
+            }
             }
         }
         .frame(width: 560, height: 600)
@@ -263,6 +308,19 @@ struct SettingsView: View {
         store.pauseAfterSeconds == 0
             ? "Wallpapers keep playing"
             : "Plays for \(durationLabel(store.pauseAfterSeconds)), then holds on a frame"
+    }
+
+    /// Says what macOS will do, not what the menu is called. "System default"
+    /// is the honest answer on a Mac where the preference has never been set:
+    /// there is no system-wide plist to read it from and loginwindow does not
+    /// publish the number it falls back to.
+    private var screenSaverSubtitle: String {
+        guard let seconds = screenSaverDelay else {
+            return "macOS is deciding. Pick a time to set it."
+        }
+        return seconds <= 0
+            ? "The screen saver never starts"
+            : "Starts after \(durationLabel(seconds)) with no activity"
     }
 
     /// Says what is about to happen in counts, and names the part that cannot

--- a/Muro/Sources/MuroApp/Store.swift
+++ b/Muro/Sources/MuroApp/Store.swift
@@ -142,27 +142,44 @@ enum MacHardware {
     }
 }
 
-/// One place a wallpaper can be showing: a display, and which of that
-/// display's two surfaces.
+/// One place a wallpaper can be showing.
 ///
-/// A Mac with two monitors has four of these, and Muro can hold a different
+/// A Mac with two monitors has five of these: a desktop and a lock screen on
+/// each, and one screen saver for the whole machine. Muro can hold a different
 /// wallpaper in every one, so a label that only ever named the display could
-/// not tell two of them apart.
+/// not tell them apart.
 struct AppliedPlace: Identifiable, Equatable {
-    let display: DisplayInfo
-    let isLockScreen: Bool
+    enum Kind: String, Equatable {
+        case desktop
+        case lockScreen
+        /// One setting for the whole Mac, so it has no display of its own.
+        /// See LockScreenService.storeTargetKey.
+        case screenSaver
+    }
 
-    var id: String { display.id + (isLockScreen ? "#lock" : "#desktop") }
+    /// Nil for the screen saver, which is not a per-display place.
+    let display: DisplayInfo?
+    let kind: Kind
+
+    var id: String { (display?.id ?? "all") + "#" + kind.rawValue }
 
     /// For the small chip on a card. Upper case, and short, because it has a
     /// card corner to fit into.
     var chipLabel: String {
-        isLockScreen ? display.chipLabel + " LOCK" : display.chipLabel
+        switch kind {
+        case .desktop: return display?.chipLabel ?? "ALL DISPLAYS"
+        case .lockScreen: return (display?.chipLabel ?? "ALL DISPLAYS") + " LOCK"
+        case .screenSaver: return "SCREEN SAVER"
+        }
     }
 
     /// For anywhere there is room to read a sentence.
     var fullLabel: String {
-        isLockScreen ? "\(display.displayName) lock screen" : display.displayName
+        switch kind {
+        case .desktop: return display?.displayName ?? "all displays"
+        case .lockScreen: return "\(display?.displayName ?? "all displays") lock screen"
+        case .screenSaver: return "the screen saver"
+        }
     }
 }
 
@@ -1223,12 +1240,21 @@ final class AppStore: ObservableObject {
         var out: [AppliedPlace] = []
         for display in displays {
             if config.assignment(forDisplayUUID: display.id)?.wallpaperID == id {
-                out.append(AppliedPlace(display: display, isLockScreen: false))
+                out.append(AppliedPlace(display: display, kind: .desktop))
             }
             if lockScreenAvailable,
                lockScreen.isApplied(wallpaperID: id, target: .display(display.id)) {
-                out.append(AppliedPlace(display: display, isLockScreen: true))
+                out.append(AppliedPlace(display: display, kind: .lockScreen))
             }
+        }
+        // One place however many displays there are, because the screen saver
+        // is one setting for the whole Mac. It was missing here entirely, so a
+        // wallpaper that was only the screen saver wore no chip at all and
+        // there was nowhere in the library to see what the screen saver was
+        // (owner, 2026-09-10).
+        if lockScreenAvailable,
+           lockScreen.isApplied(wallpaperID: id, target: .all, surface: .screenSaver) {
+            out.append(AppliedPlace(display: nil, kind: .screenSaver))
         }
         return out
     }
@@ -1247,9 +1273,12 @@ final class AppStore: ObservableObject {
 
     private func appliedSpread(_ places: [AppliedPlace]) -> AppliedSpread {
         let screens = displays.count
-        let desktops = places.filter { !$0.isLockScreen }.count
-        let locks = places.count - desktops
+        let desktops = places.filter { $0.kind == .desktop }.count
+        let locks = places.filter { $0.kind == .lockScreen }.count
+        let saver = places.contains { $0.kind == .screenSaver }
+        // A desktop and a lock screen per display, plus the one screen saver.
         let everyPlace = screens * (lockScreenAvailable ? 2 : 1)
+            + (lockScreenAvailable ? 1 : 0)
 
         // "Everywhere" only reads as true when there is a lock screen it could
         // also have gone to. On a Mac that cannot do lock screens, covering
@@ -1258,8 +1287,10 @@ final class AppStore: ObservableObject {
         if places.count >= everyPlace {
             return lockScreenAvailable ? .everywhere : .allDisplays
         }
-        if locks == 0, desktops == screens { return .allDisplays }
-        if desktops == 0, locks == screens { return .allLockScreens }
+        // These two still have to mean what they say, so the screen saver
+        // being in the list rules them both out.
+        if locks == 0, !saver, desktops == screens { return .allDisplays }
+        if desktops == 0, !saver, locks == screens { return .allLockScreens }
         return .some(places.count)
     }
 

--- a/Muro/Sources/MuroApp/Store.swift
+++ b/Muro/Sources/MuroApp/Store.swift
@@ -993,7 +993,8 @@ final class AppStore: ObservableObject {
                         videoURL: videoURL,
                         thumbnailURL: thumbnailURL,
                         target: target,
-                        surface: appleSurface
+                        surface: appleSurface,
+                        connectedDisplays: Set(displays.map(\.id))
                     )
                     if outcome == .needsSystemSettings { lockScreenNeedsSystemSettings = true }
                 }

--- a/Muro/Sources/MuroApp/Store.swift
+++ b/Muro/Sources/MuroApp/Store.swift
@@ -50,8 +50,32 @@ enum ApplyTarget: Equatable {
     case display(String)
 }
 
+/// Where a wallpaper is being put.
+///
+/// `all` was called "Both" while there were two of them. The screen saver is
+/// the third, and it is a separate key in Apple's own store from the one the
+/// lock screen renders, so it is set separately here too.
 enum ApplySurface: String, CaseIterable {
-    case both = "Both", desktop = "Desktop", lockscreen = "Lockscreen"
+    case all = "All", desktop = "Desktop", lockscreen = "Lockscreen"
+    case screensaver = "Screensaver"
+
+    /// Whether this choice covers Muro's own desktop engine.
+    var coversDesktop: Bool { self == .desktop || self == .all }
+    /// Whether it covers the Apple-managed surface the lock screen renders.
+    var coversLockScreen: Bool { self == .lockscreen || self == .all }
+    /// Whether it covers the screen saver.
+    var coversScreenSaver: Bool { self == .screensaver || self == .all }
+
+    /// The Apple store roles this choice writes, in the order they are applied.
+    var appleSurfaces: [AppleWallpaperStore.Surface] {
+        var out: [AppleWallpaperStore.Surface] = []
+        if coversLockScreen { out.append(.desktop) }
+        if coversScreenSaver { out.append(.screenSaver) }
+        return out
+    }
+
+    /// Whether macOS 26 is needed for this choice.
+    var needsAppleExtension: Bool { self != .desktop }
 }
 
 /// What to call the screen built into this Mac.
@@ -216,7 +240,7 @@ final class AppStore: ObservableObject {
     @Published var whatsNewOpen = false
     @Published var previewItem: WallpaperItem?
     @Published var previewMode = "smooth"
-    @Published var applySurface: ApplySurface = .both
+    @Published var applySurface: ApplySurface = .all
     @Published var heroID: String?
     @Published var libraryBytes: Int64 = 0
     /// What the last Clear actually did. Shown in Settings, because a Clear
@@ -899,6 +923,7 @@ final class AppStore: ObservableObject {
     /// Lock screens need macOS 26 and the embedded extension.
     var lockScreenAvailable: Bool { lockScreen.isAvailable }
     var lockScreenWallpaperID: String? { lockScreen.activeWallpaperID }
+    var screenSaverWallpaperID: String? { lockScreen.screenSaverWallpaperID }
 
     /// Applying to one surface leaves the other alone.
     ///
@@ -934,14 +959,15 @@ final class AppStore: ObservableObject {
             entry = refreshed
         }
 
-        // A Both apply is committed to the desktop engine only after the
-        // lock-screen transaction succeeds, so a failed extension/store write
+        // An All apply is committed to the desktop engine only after the
+        // Apple-side transaction succeeds, so a failed extension/store write
         // cannot leave the UI in a silently half-applied state.
         if surface == .desktop {
             applyAssignment(id: entry.id, mode: resolvedMode, target: target)
         }
 
-        if surface == .lockscreen || surface == .both {
+        let appleSurfaces = surface.appleSurfaces
+        if !appleSurfaces.isEmpty {
             guard lockScreenAvailable else {
                 applyError = LockScreenServiceError.requiresTahoe.localizedDescription
                 return
@@ -958,14 +984,20 @@ final class AppStore: ObservableObject {
             applyingLockScreen = true
             defer { applyingLockScreen = false }
             do {
-                let outcome = try await lockScreen.apply(
-                    entry: entry,
-                    videoURL: videoURL,
-                    thumbnailURL: thumbnailURL,
-                    target: target
-                )
-                if outcome == .needsSystemSettings { lockScreenNeedsSystemSettings = true }
-                if surface == .both {
+                // One pass per role. They write different keys in Apple's
+                // store, so the screen saver does not displace the lock screen
+                // and neither has to be given up for the other.
+                for appleSurface in appleSurfaces {
+                    let outcome = try await lockScreen.apply(
+                        entry: entry,
+                        videoURL: videoURL,
+                        thumbnailURL: thumbnailURL,
+                        target: target,
+                        surface: appleSurface
+                    )
+                    if outcome == .needsSystemSettings { lockScreenNeedsSystemSettings = true }
+                }
+                if surface == .all {
                     applyAssignment(id: entry.id, mode: resolvedMode, target: target)
                 } else {
                     pushRecent(entry.id)
@@ -1008,10 +1040,14 @@ final class AppStore: ObservableObject {
             desktopApplied = config.assignment(forDisplayUUID: uuid)?.wallpaperID == item.id
         }
         let lockApplied = lockScreen.isApplied(wallpaperID: item.id, target: target)
+        let saverApplied = lockScreen.isApplied(
+            wallpaperID: item.id, target: target, surface: .screenSaver
+        )
         switch surface {
         case .desktop: return desktopApplied
         case .lockscreen: return lockApplied
-        case .both: return desktopApplied && lockApplied
+        case .screensaver: return saverApplied
+        case .all: return desktopApplied && lockApplied && saverApplied
         }
     }
 
@@ -1023,7 +1059,7 @@ final class AppStore: ObservableObject {
         target: ApplyTarget,
         surface: ApplySurface = .desktop
     ) {
-        if surface == .desktop || surface == .both {
+        if surface.coversDesktop {
             switch target {
             case .all:
                 if config.allDisplays?.wallpaperID == item.id { config.allDisplays = nil }
@@ -1042,15 +1078,17 @@ final class AppStore: ObservableObject {
             }
             saveConfig()
         }
-        if surface == .lockscreen || surface == .both {
-            Task {
-                do {
-                    try await lockScreen.remove(target: target)
-                    objectWillChange.send()
-                    recomputeSize()
-                } catch {
-                    applyError = error.localizedDescription
+        let appleSurfaces = surface.appleSurfaces
+        guard !appleSurfaces.isEmpty else { return }
+        Task {
+            do {
+                for appleSurface in appleSurfaces {
+                    try await lockScreen.remove(target: target, surface: appleSurface)
                 }
+                objectWillChange.send()
+                recomputeSize()
+            } catch {
+                applyError = error.localizedDescription
             }
         }
     }
@@ -1529,15 +1567,19 @@ final class AppStore: ObservableObject {
         }
         if configChanged { saveConfig() }
 
-        // 2. Off the lock screen. That surface keeps its own staged copy of
-        //    the video inside the extension container and a record in Apple's
-        //    wallpaper store, so removing the selection is what puts the
-        //    user's real wallpaper back and releases the copy.
-        for target in lockScreen.targets(showing: ids) {
-            do {
-                try await lockScreen.remove(target: target)
-            } catch {
-                applyError = error.localizedDescription
+        // 2. Off the lock screen and the screen saver. Those keep their own
+        //    staged copy of the video inside the extension container and a
+        //    record in Apple's wallpaper store, so removing the selection is
+        //    what puts the user's real wallpaper back and releases the copy.
+        //    Both roles are swept: a wallpaper deleted while it was only the
+        //    screen saver used to leave its record and its staged file behind.
+        for role in [AppleWallpaperStore.Surface.desktop, .screenSaver] {
+            for target in lockScreen.targets(showing: ids, surface: role) {
+                do {
+                    try await lockScreen.remove(target: target, surface: role)
+                } catch {
+                    applyError = error.localizedDescription
+                }
             }
         }
 

--- a/Muro/Sources/MuroKit/AppleWallpaperStore.swift
+++ b/Muro/Sources/MuroKit/AppleWallpaperStore.swift
@@ -21,6 +21,11 @@ import Foundation
 /// renders whatever fills the desktop role: `Desktop` on an individual node,
 /// `Linked` on a linked one.
 ///
+/// **The screen saver is the other role**, and it is `Idle` on an individual
+/// node. A `linked` node is the one place the two roles are the same key:
+/// linking a Mac's desktop and screen saver is what that type means, so one
+/// wallpaper serves both and neither can be set without the other.
+///
 /// Muro used to write `Desktop` on every node regardless of its `Type`. On a
 /// Mac whose desktop and lock screen are linked, that put the wallpaper under
 /// a key macOS never reads, so the lock screen went on showing whatever
@@ -45,19 +50,34 @@ public enum AppleWallpaperStore {
         surfaceNames.contains { node[$0] is [String: Any] }
     }
 
-    /// The key this node keeps the wallpaper the lock screen renders under, or
-    /// `nil` when Muro has no business writing to this node at all.
+    /// The two roles a wallpaper can fill. Which key each one lands on depends
+    /// on the node, which is what the rest of this file is about.
+    public enum Surface: Sendable {
+        /// The desktop, and with it the lock screen, which has no key of its own.
+        case desktop
+        /// The screen saver.
+        case screenSaver
+    }
+
+    /// The key this node keeps the wallpaper for `surface` under, or `nil`
+    /// when Muro has no business writing to this node at all.
     ///
-    /// `idle` is the screen saver on its own. Writing there would make Muro
-    /// the screen saver rather than the wallpaper, which is not what anybody
-    /// asked for, so those nodes are left alone. A node carrying no `Type` at
-    /// all keeps the old behaviour and gets `Desktop`.
-    public static func desktopSurfaceName(of node: [String: Any]) -> String? {
+    /// A node typed `idle` carries the screen saver and nothing else, so the
+    /// desktop role has nowhere to go on it and leaves it alone. Everything
+    /// else has a key for both roles, or can be given one. A node carrying no
+    /// `Type` at all keeps the old behaviour and gets `Desktop`.
+    public static func surfaceName(of node: [String: Any], for surface: Surface) -> String? {
         switch node["Type"] as? String {
         case "linked": return "Linked"
-        case "idle": return nil
-        default: return "Desktop"
+        case "idle" where surface == .desktop: return nil
+        default: return surface == .screenSaver ? "Idle" : "Desktop"
         }
+    }
+
+    /// The key the lock screen renders from. Unchanged shorthand for the
+    /// desktop role, kept because it is what most of the app asks for.
+    public static func desktopSurfaceName(of node: [String: Any]) -> String? {
+        surfaceName(of: node, for: .desktop)
     }
 
     /// Puts one choice into a surface, leaving everything else about it alone.
@@ -153,17 +173,31 @@ public enum AppleWallpaperStore {
         _ choice: [String: Any],
         to store: inout Any,
         targetKey: String,
+        surface: Surface = .desktop,
+        missingSurface: [String: Any] = [:],
         now: Date = Date()
     ) -> Int {
         var written = 0
         mutateNodes(in: &store) { path, node in
             guard targetKey == "all" || path.contains(targetKey) else { return node }
-            guard let name = desktopSurfaceName(of: node),
-                  let surface = node[name] as? [String: Any]
-            else { return node }
+            guard let name = surfaceName(of: node, for: surface) else { return node }
+            if let existing = node[name] as? [String: Any] {
+                written += 1
+                var updated = node
+                updated[name] = surfaceApplying(choice: choice, to: existing, now: now)
+                return updated
+            }
+            // Only the screen saver reaches here, and only on a node that has
+            // never had one: `desktop` says so outright, and an untyped node
+            // can carry a `Desktop` alone. The desktop role always names a key
+            // its own node already has, so nothing about it changes.
+            guard surface == .screenSaver else { return node }
             written += 1
             var updated = node
-            updated[name] = surfaceApplying(choice: choice, to: surface, now: now)
+            updated[name] = surfaceApplying(choice: choice, to: missingSurface, now: now)
+            // A node that now carries both is an individual one, and saying so
+            // is the same honesty `nodeApplying` keeps in the other direction.
+            if updated["Type"] as? String == "desktop" { updated["Type"] = "individual" }
             return updated
         }
         return written
@@ -235,6 +269,7 @@ public enum AppleWallpaperStore {
     public static func ensureNode(
         at path: [String],
         choice: [String: Any],
+        surface: Surface = .desktop,
         desktopFallback: [String: Any],
         idleFallback: [String: Any],
         root: inout Any,
@@ -247,12 +282,14 @@ public enum AppleWallpaperStore {
                 nodeApplying(
                     choice: choice,
                     to: $0,
+                    surface: surface,
                     desktopFallback: desktopFallback,
                     idleFallback: idleFallback,
                     now: now
                 )
             } ?? makeNode(
                 choice: choice,
+                surface: surface,
                 desktopFallback: desktopFallback,
                 idleFallback: idleFallback,
                 now: now
@@ -265,6 +302,7 @@ public enum AppleWallpaperStore {
         ensureNode(
             at: Array(path.dropFirst()),
             choice: choice,
+            surface: surface,
             desktopFallback: desktopFallback,
             idleFallback: idleFallback,
             root: &nested,
@@ -286,16 +324,25 @@ public enum AppleWallpaperStore {
         _ choice: [String: Any],
         to store: inout Any,
         targetKey: String,
+        surface: Surface = .desktop,
         desktopFallback: [String: Any],
         idleFallback: [String: Any],
         now: Date = Date()
     ) -> Int {
-        let written = applyChoice(choice, to: &store, targetKey: targetKey, now: now)
+        let written = applyChoice(
+            choice,
+            to: &store,
+            targetKey: targetKey,
+            surface: surface,
+            missingSurface: surface == .screenSaver ? idleFallback : desktopFallback,
+            now: now
+        )
         guard written == 0 else { return written }
         for path in fallbackNodePaths(in: store, targetKey: targetKey) {
             ensureNode(
                 at: path,
                 choice: choice,
+                surface: surface,
                 desktopFallback: desktopFallback,
                 idleFallback: idleFallback,
                 root: &store,
@@ -316,16 +363,25 @@ public enum AppleWallpaperStore {
     public static func nodeApplying(
         choice: [String: Any],
         to node: [String: Any],
+        surface: Surface = .desktop,
         desktopFallback: [String: Any],
         idleFallback: [String: Any],
         now: Date = Date()
     ) -> [String: Any] {
         var updated = node
-        if let name = desktopSurfaceName(of: node) {
-            let base = node[name] as? [String: Any] ?? desktopFallback
+        if let name = surfaceName(of: node, for: surface) {
+            let base = node[name] as? [String: Any]
+                ?? (name == "Idle" ? idleFallback : desktopFallback)
             updated[name] = surfaceApplying(choice: choice, to: base, now: now)
+            if name == "Idle", updated["Desktop"] == nil, updated["Linked"] == nil {
+                updated["Desktop"] = desktopFallback
+            }
+            if name == "Idle", updated["Type"] as? String == "desktop" {
+                updated["Type"] = "individual"
+            }
             return updated
         }
+        // Only the desktop role reaches here, on a screen-saver-only node.
         updated["Desktop"] = surfaceApplying(choice: choice, to: desktopFallback, now: now)
         if updated["Idle"] == nil { updated["Idle"] = idleFallback }
         updated["Type"] = "individual"
@@ -342,15 +398,25 @@ public enum AppleWallpaperStore {
     /// frame.
     public static func makeNode(
         choice: [String: Any],
+        surface: Surface = .desktop,
         desktopFallback: [String: Any],
         idleFallback: [String: Any],
         now: Date = Date()
     ) -> [String: Any] {
-        [
-            "Type": "individual",
-            "Desktop": surfaceApplying(choice: choice, to: desktopFallback, now: now),
-            "Idle": idleFallback,
-        ]
+        switch surface {
+        case .desktop:
+            return [
+                "Type": "individual",
+                "Desktop": surfaceApplying(choice: choice, to: desktopFallback, now: now),
+                "Idle": idleFallback,
+            ]
+        case .screenSaver:
+            return [
+                "Type": "individual",
+                "Desktop": desktopFallback,
+                "Idle": surfaceApplying(choice: choice, to: idleFallback, now: now),
+            ]
+        }
     }
 
     /// Whether a node describes itself honestly: every surface it carries is

--- a/Muro/Sources/MuroKit/AppleWallpaperStore.swift
+++ b/Muro/Sources/MuroKit/AppleWallpaperStore.swift
@@ -160,6 +160,45 @@ public enum AppleWallpaperStore {
         return found
     }
 
+    /// Whether this store holds `provider` **in one particular role**, for one
+    /// particular target.
+    ///
+    /// `containsProvider` answers a different and much broader question, "is
+    /// Muro anywhere in this file at all", and it has to stay that way:
+    /// `healIfNeeded` uses it to decide whether macOS has thrown Muro out
+    /// altogether, and a stricter test there would make Muro tear down a
+    /// perfectly good lock screen because the screen saver alone was missing.
+    ///
+    /// **This is the question an apply needs and never asked.** Muro keeps two
+    /// store files and writes both. On 2026-09-10 the owner's Mac ended up
+    /// with the screen saver role held by Muro in `Index2.plist` and by
+    /// Apple's default in `Index.plist`, which is the file macOS was reading,
+    /// so the screen saver showed Apple's aerial wallpaper. The apply that
+    /// should have repaired it asked `containsProvider`, got `true` from the
+    /// wrong file, called itself settled and stopped retrying. Asking per role,
+    /// per target and per file is what makes the retry loop retry.
+    public static func holdsRole(
+        _ provider: String,
+        in store: Any?,
+        targetKey: String,
+        surface: Surface
+    ) -> Bool {
+        guard let store else { return false }
+        var found = false
+        forEachNode(in: store) { path, node in
+            guard !found else { return }
+            // The key this node keeps the role under, which is not the same on
+            // every node: a linked node carries both roles on `Linked`, and an
+            // `idle` node has no desktop at all.
+            guard let name = surfaceName(of: node, for: surface),
+                  let occupant = node[name] as? [String: Any],
+                  surfaceBelongsToTarget(path + [name], targetKey: targetKey)
+            else { return }
+            if providers(of: occupant).contains(provider) { found = true }
+        }
+        return found
+    }
+
     /// Writes `choice` into the surface each matching node actually uses.
     ///
     /// `targetKey` is either `"all"` or a display UUID, matched against the

--- a/Muro/Sources/MuroKit/DisplayID.swift
+++ b/Muro/Sources/MuroKit/DisplayID.swift
@@ -26,3 +26,17 @@ public func displayIsBuiltIn(_ screen: NSScreen) -> Bool? {
     }
     return CGDisplayIsBuiltin(CGDirectDisplayID(number.uint32Value)) != 0
 }
+
+/// The `CGDirectDisplayID` macOS puts in a wallpaper extension's acquire
+/// request, so the app can name a staged file the extension will look for.
+///
+/// The UUID is the stable identity and is what everything else keys on. This
+/// number is not stable across reboots or replugs, which is exactly why it is
+/// used for nothing but the filename of a picture that is restaged whenever
+/// the displays change.
+public func directDisplayID(for screen: NSScreen) -> CGDirectDisplayID? {
+    guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
+        as? NSNumber
+    else { return nil }
+    return CGDirectDisplayID(number.uint32Value)
+}

--- a/Muro/Sources/MuroKit/LockScreenSelections.swift
+++ b/Muro/Sources/MuroKit/LockScreenSelections.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// What Muro is holding on the lock screen, per display.
+///
+/// **The bug this exists to stop.** Applying a lock screen replaced the whole
+/// record with a single entry, whatever it had been applied to. So setting one
+/// wallpaper on the MacBook and a different one on an external display left
+/// only the second: the first display's entry was gone, its staged video was
+/// swept as unreferenced, and the desktop-still writer, which skips a display
+/// only while Muro's record says it owns that display's slot, then wrote a
+/// picture straight into it. The user saw the right wallpaper on that screen,
+/// frozen, and there was nothing in any log to say why (owner's Mac,
+/// 2026-09-10, MacBook plus a DELL P2219H).
+///
+/// **Why it was written that way, which still matters.** Every staged
+/// wallpaper appears as its own row in System Settings, and keeping a
+/// selection per apply grew that list a row at a time until it read as
+/// leftovers nobody could clear. That was #25, #26 and #27. Replacing
+/// everything fixed it and cost the second display.
+///
+/// So the rule is one selection per **connected display**, not one for the
+/// whole Mac and not one per apply. Two displays can hold two, which is the
+/// point, and nothing else can accumulate: an entry for a display that is not
+/// plugged in now is dropped, so unplugging a monitor cleans up after itself.
+public enum LockScreenSelections {
+    /// The key that stands for every display at once.
+    public static let allKey = "all"
+
+    /// The record after applying `wallpaperID` to `targetKey`.
+    ///
+    /// - Parameters:
+    ///   - current: what is held now, keyed by display UUID or `all`.
+    ///   - targetKey: a display UUID, or `all`.
+    ///   - connectedDisplays: the UUIDs plugged in right now. An entry for
+    ///     anything else is dropped, which is what keeps this bounded.
+    public static func afterApply(
+        current: [String: String],
+        targetKey: String,
+        wallpaperID: String,
+        connectedDisplays: Set<String>
+    ) -> [String: String] {
+        // Every display at once supersedes each of them individually, so it
+        // stands alone. This is the case that was already right.
+        if targetKey == allKey { return [allKey: wallpaperID] }
+        // `all` is kept beside a per-display entry on purpose: it is still
+        // what any display without one of its own is reading, so dropping it
+        // would tell the still writer those screens are free when they are not.
+        var next = current.filter { key, _ in
+            key == allKey || connectedDisplays.contains(key)
+        }
+        next[targetKey] = wallpaperID
+        return next
+    }
+}

--- a/Muro/Sources/MuroKit/ScreenSaverDelay.swift
+++ b/Muro/Sources/MuroKit/ScreenSaverDelay.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// How long the Mac sits idle before its screen saver starts.
+///
+/// Muro can already be the screen saver, so sending the user into System
+/// Settings for the one number that decides when it runs was the last errand
+/// left in the feature. This is that number.
+///
+/// **It is Apple's preference, not one of Muro's**, so it is read and written
+/// exactly where Apple keeps it and nowhere else: the key `idleTime` in
+/// `com.apple.screensaver`, current user, **current host**. The by-host part
+/// is not a detail. `CFPreferencesCopyAppValue` searches current-host before
+/// any-host, so a value written to the any-host domain is shadowed by the
+/// by-host one Apple's own panel writes, and would be silently ignored. There
+/// is no system-wide default file either: `/Library/Preferences` and
+/// `/Library/Managed Preferences` both have no `com.apple.screensaver.plist`,
+/// so this one by-host key is the whole story.
+///
+/// **Everything below was measured on macOS 26.6.2 on 2026-09-10, before any
+/// of it was written, rather than assumed:**
+///
+/// - **An ad-hoc signed binary can write it.** Tested with a throwaway tool
+///   signed the same way Muro is. Muro is not sandboxed, so there is no
+///   entitlement to acquire and no prompt for the user to answer.
+/// - **macOS adopts the new value live. No logout, nothing to restart, no
+///   process to kill.** `loginwindow`'s `ScreenSaverDaemon` calls
+///   `CFPreferencesAppSynchronize` at the top of `idleTimePreference`, on
+///   every single idle check, so it cannot read a stale value. Watched in the
+///   system log: the preference was changed to 1800 at 15:53:22, and at
+///   15:53:42 the daemon logged `idleTime: 1800`, `targetUserIdle = 1800.0`
+///   and rescheduled its timer for 1739.9s, where the previous value of 60
+///   would have started the screen saver on the spot.
+/// - **Zero means never**, and that was read out of loginwindow rather than
+///   guessed at. `_checkUserIdleDuringReset:` compares the target it just
+///   read against one second (`fmov d0, #1.0` / `fcmp d8, d0` / `b.mi`) and
+///   takes the bail branch, which returns without arming a timer and without
+///   launching anything. Nothing under a second ever starts the screen saver.
+/// - **Apple's own settings panel does this and nothing more.** Its binary,
+///   `Wallpaper.appex`, calls `CFPreferencesSetValue` and contains no
+///   `notify_post` at all, so there is no nudge to the daemon being missed
+///   here. Both Apple and Muro leave the daemon to notice at its next idle
+///   check, which any key press or mouse movement brings on.
+public enum ScreenSaverDelay {
+    private static let domain = "com.apple.screensaver" as CFString
+    private static let key = "idleTime" as CFString
+
+    /// The value that stops the screen saver ever starting.
+    ///
+    /// Apple's menu calls it "Never". loginwindow has no separate concept for
+    /// it: it is just a target below one second, which its own guard refuses
+    /// to act on.
+    public static let never = 0
+
+    /// The same durations Apple's menu offers, in Apple's order.
+    ///
+    /// Read off the real menu rather than invented, so a user who knows the
+    /// system panel finds the list they expect. Nothing stops another value
+    /// being written by hand, and `label` renders those too, but Muro only
+    /// ever offers these.
+    public static let choices: [Int] = [
+        60, 120, 180, 300, 600, 1200, 1800,
+        3600, 5400, 7200, 9000, 10800,
+        never,
+    ]
+
+    /// What the row says when the preference is absent.
+    ///
+    /// It genuinely is absent on a Mac where nobody has ever touched the
+    /// setting: there is no system-wide plist to fall back to, and loginwindow
+    /// uses a number compiled into itself that it does not publish anywhere.
+    /// Muro says so instead of inventing a duration and showing it as fact.
+    public static let systemDefaultLabel = "System default"
+
+    /// The menu wording for a delay, or for not knowing one.
+    public static func label(_ seconds: Int?) -> String {
+        guard let seconds else { return systemDefaultLabel }
+        return seconds <= 0 ? "Never" : durationLabel(seconds)
+    }
+
+    /// What macOS will actually wait, or nil when nobody has ever set it.
+    public static func current() -> Int? {
+        let value = CFPreferencesCopyValue(
+            key, domain, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost
+        )
+        return (value as? NSNumber)?.intValue
+    }
+
+    /// Sets it, then reports what is actually there.
+    ///
+    /// The read-back is the point of the return value: the UI shows what macOS
+    /// holds rather than what Muro hoped to write, so a refusal shows up in
+    /// the row instead of being invisible until the screen saver misbehaves.
+    @discardableResult
+    public static func set(_ seconds: Int) -> Int? {
+        CFPreferencesSetValue(
+            key, NSNumber(value: max(0, seconds)), domain,
+            kCFPreferencesCurrentUser, kCFPreferencesCurrentHost
+        )
+        CFPreferencesSynchronize(domain, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost)
+        return current()
+    }
+}

--- a/Muro/Sources/MuroWallpaperExtension/DesktopStill.swift
+++ b/Muro/Sources/MuroWallpaperExtension/DesktopStill.swift
@@ -16,11 +16,28 @@ import ImageIO
 /// underneath the video, and the video is hidden whenever it is not playing.
 /// Restaged whenever the desktop wallpaper changes, including on every
 /// playlist and automation step.
+/// **One picture per display.** A Mac with two screens has two desktop
+/// wallpapers, and this used to hand every surface the same one: whatever the
+/// main display was set to. So after quitting Muro the second display showed
+/// the first display's picture, which reads as the wallpapers having swapped
+/// (owner, 2026-09-10). The app stages one file per display now, named by the
+/// same `CGDirectDisplayID` macOS puts in the acquire request, and the
+/// unnumbered file stays as the fallback for a surface that names no display.
 enum DesktopStill {
-    static var url: URL? {
-        let url = documentsURL.appendingPathComponent("desktop-still.jpg")
-        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    /// The file for one display, or the shared one, whichever exists.
+    static func url(displayID: UInt32?) -> URL? {
+        let manager = FileManager.default
+        if let displayID {
+            let perDisplay = documentsURL
+                .appendingPathComponent("desktop-still-\(displayID).jpg")
+            if manager.fileExists(atPath: perDisplay.path) { return perDisplay }
+        }
+        let shared = documentsURL.appendingPathComponent("desktop-still.jpg")
+        return manager.fileExists(atPath: shared.path) ? shared : nil
     }
+
+    /// Whether there is any picture staged at all. For the log line only.
+    static var url: URL? { url(displayID: nil) }
 
     /// The last decode, kept against the file it came from.
     ///
@@ -30,27 +47,33 @@ enum DesktopStill {
     /// changed, so it is decoded once per version of the file. Size and
     /// modification date together are what change when the app stages a new
     /// one, since it copies the picture in rather than writing it.
+    /// Keyed by file path now, because two displays decode two files and one
+    /// slot would make them evict each other on every reassert.
     private static let memoryLock = NSLock()
-    nonisolated(unsafe) private static var memory: (key: String, image: CGImage)?
+    nonisolated(unsafe) private static var memory: [String: (key: String, image: CGImage)] = [:]
 
-    static func current() -> CGImage? {
-        guard let url else {
-            memoryLock.lock()
-            memory = nil
-            memoryLock.unlock()
-            return nil
-        }
+    static func current(displayID: UInt32? = nil) -> CGImage? {
+        guard let url = url(displayID: displayID) else { return nil }
+        let path = url.path
         let key = identity(of: url)
         memoryLock.lock()
-        let remembered = memory?.key == key ? memory?.image : nil
+        let remembered = memory[path]?.key == key ? memory[path]?.image : nil
         memoryLock.unlock()
         if let remembered { return remembered }
 
         guard let decoded = image(at: url) else { return nil }
         memoryLock.lock()
-        memory = (key, decoded)
+        memory[path] = (key, decoded)
         memoryLock.unlock()
         return decoded
+    }
+
+    /// Drops decodes for files the app has taken away, so a display that is
+    /// unplugged does not keep a 4K bitmap alive for the life of the process.
+    static func forgetMissingFiles() {
+        memoryLock.lock()
+        memory = memory.filter { FileManager.default.fileExists(atPath: $0.key) }
+        memoryLock.unlock()
     }
 
     /// What the file is right now, cheaply: its size and modification date.

--- a/Muro/Sources/MuroWallpaperExtension/RendererState.swift
+++ b/Muro/Sources/MuroWallpaperExtension/RendererState.swift
@@ -92,6 +92,12 @@ final class ActiveWallpaper: @unchecked Sendable {
     /// screen saver, which is not the desktop either.
     let drawsStill: Bool
 
+    /// The display this surface is drawing on, as macOS named it in the
+    /// acquire request. Kept so a reassert can fetch this display's own
+    /// desktop picture rather than the main display's. Nil when macOS named
+    /// no display, which is the whole-Mac fallback.
+    let displayID: UInt32?
+
     /// Whether macOS built this surface to *be* the screen saver.
     ///
     /// Fixed at creation, and the only thing that separates the screen saver
@@ -119,8 +125,10 @@ final class ActiveWallpaper: @unchecked Sendable {
         choiceID: String?,
         drawsStill: Bool,
         isScreenSaverSurface: Bool = false,
+        displayID: UInt32? = nil,
         fallback: CGImage?
     ) {
+        self.displayID = displayID
         self.context = context
         self.rootLayer = rootLayer
         self.renderer = renderer
@@ -289,7 +297,7 @@ final class RendererState: @unchecked Sendable {
         presentationMode = mode
         activityState = activity
         lock.unlock()
-        extensionTrace("presentation mode=\(mode) activity=\(activity)")
+        extensionLog("presentation mode=\(mode) activity=\(activity)")
         // The picture is drawn again, not only re-paused. Unlocking, and
         // logging in, are the moments the desktop comes back into view, and a
         // desktop that came up with nothing on it has to be repainted at the
@@ -355,6 +363,16 @@ final class RendererState: @unchecked Sendable {
     func applyCurrentPlaybackPolicy() {
         let shouldPlay = shouldPlayNow()
         let saverPlays = shouldScreenSaverPlay()
+        // The line `7ee55c0` asked for and nobody added. A desktop that comes
+        // back wrong is answered by this and nothing else: it says, per
+        // surface, what was decided and whether there was a picture to decide
+        // it with.
+        extensionLog(
+            "policy desktop=\(shouldPlay ? "play" : "still") "
+                + "saver=\(saverPlays ? "play" : "still") "
+                + "covered=\(ScreenState.isCovered()) "
+                + surfaceSummary()
+        )
         forEachWallpaper { wallpaper in
             // The desktop's answer is not the screen saver's. While the screen
             // saver is up the desktop is behind it and holding still, and
@@ -367,9 +385,28 @@ final class RendererState: @unchecked Sendable {
 
     /// The app has staged a different desktop picture: a new wallpaper, a
     /// playlist step, or the last one being removed.
+    /// `display=1 still=yes shown=still` for each surface, for the log line
+    /// above. Short on purpose: the extension log is capped at 32 KB.
+    private func surfaceSummary() -> String {
+        forEachWallpaperCollect { wallpaper in
+            "[d=\(wallpaper.displayID.map(String.init) ?? "-")"
+                + (wallpaper.isScreenSaverSurface ? " saver" : "")
+                + " still=\(wallpaper.hasStill ? "yes" : "NO")]"
+        }.joined(separator: " ")
+    }
+
+    func forEachWallpaperCollect(_ body: (ActiveWallpaper) -> String) -> [String] {
+        lock.lock()
+        let wallpapers = Array(active.values)
+        lock.unlock()
+        return wallpapers.map(body)
+    }
+
     func refreshDesktopStill() {
-        let image = DesktopStill.current()
-        forEachWallpaper { $0.setStill(image) }
+        // Per surface, not one picture for the Mac: two displays have two
+        // desktop wallpapers and each surface has to be handed its own.
+        DesktopStill.forgetMissingFiles()
+        forEachWallpaper { $0.setStill(DesktopStill.current(displayID: $0.displayID)) }
         applyCurrentPlaybackPolicy()
     }
 
@@ -411,6 +448,8 @@ final class RendererState: @unchecked Sendable {
         let removed = active.removeValue(forKey: key)
         lock.unlock()
         removed?.renderer.stop()
-        if removed != nil { extensionTrace("released inactive wallpaper surface") }
+        if removed != nil {
+            extensionLog("released surface d=\(key.displayID) left=\(activeCount)")
+        }
     }
 }

--- a/Muro/Sources/MuroWallpaperExtension/RendererState.swift
+++ b/Muro/Sources/MuroWallpaperExtension/RendererState.swift
@@ -24,6 +24,15 @@ struct WallpaperRequestInfo {
     /// put on a lock screen.
     var presentationMode: String?
     var activityState: String?
+
+    /// Whether macOS is asking for the screen saver.
+    ///
+    /// `WallpaperPresentationMode` has exactly three cases, `default`,
+    /// `locked` and `idle`, and `idle` is the screen saver: the same word
+    /// Apple's own wallpaper store keeps it under. The creation request
+    /// carries no content type of any kind, so this is the only thing that
+    /// says it.
+    var isScreenSaver: Bool { presentationMode == "idle" }
 }
 
 func inspectWallpaperRequest(_ request: Any?) -> WallpaperRequestInfo {
@@ -79,8 +88,17 @@ final class ActiveWallpaper: @unchecked Sendable {
 
     /// Whether this surface draws the desktop's own picture at all. False for
     /// a System Settings preview, which is showing the lock wallpaper on
-    /// purpose and should not be handed the desktop's.
+    /// purpose and should not be handed the desktop's, and false for the
+    /// screen saver, which is not the desktop either.
     let drawsStill: Bool
+
+    /// Whether macOS built this surface to *be* the screen saver.
+    ///
+    /// Fixed at creation, and the only thing that separates the screen saver
+    /// from every other surface. macOS creates one when the screen saver
+    /// starts and takes it away when it stops, so a surface that has it is the
+    /// screen saver for as long as it exists.
+    let isScreenSaverSurface: Bool
 
     /// A frame of this wallpaper itself, kept so a desktop still going away
     /// falls back to something rather than to nothing.
@@ -100,6 +118,7 @@ final class ActiveWallpaper: @unchecked Sendable {
         renderer: VideoRenderer,
         choiceID: String?,
         drawsStill: Bool,
+        isScreenSaverSurface: Bool = false,
         fallback: CGImage?
     ) {
         self.context = context
@@ -107,6 +126,7 @@ final class ActiveWallpaper: @unchecked Sendable {
         self.renderer = renderer
         self.choiceID = choiceID
         self.drawsStill = drawsStill
+        self.isScreenSaverSurface = isScreenSaverSurface
         self.fallback = fallback
     }
 
@@ -314,11 +334,34 @@ final class RendererState: @unchecked Sendable {
         return !ExtensionPreferences.shared.alwaysPauseDesktop
     }
 
+    /// Whether the screen saver surface should be playing.
+    ///
+    /// Deliberately a rule of its own rather than another branch inside
+    /// `shouldPlayNow`. The desktop rule is settled behaviour that the lock
+    /// screen depends on, and the screen saver has nothing in common with it:
+    /// it exists only while it is the thing on screen, so being asked for it
+    /// at all is the answer. `alwaysPauseDesktop` in particular must not
+    /// reach it, since Muro's own window is not up there to keep still for.
+    ///
+    /// The one exception is macOS saying this surface is suspended, which
+    /// means it is not being shown after all.
+    func shouldScreenSaverPlay() -> Bool {
+        lock.lock()
+        let activity = activityState
+        lock.unlock()
+        return !activity.contains("suspended")
+    }
+
     func applyCurrentPlaybackPolicy() {
         let shouldPlay = shouldPlayNow()
+        let saverPlays = shouldScreenSaverPlay()
         forEachWallpaper { wallpaper in
-            shouldPlay ? wallpaper.renderer.resume() : wallpaper.renderer.pause()
-            wallpaper.setShowingStill(!shouldPlay)
+            // The desktop's answer is not the screen saver's. While the screen
+            // saver is up the desktop is behind it and holding still, and
+            // giving that answer to both is what froze the screen saver.
+            let play = wallpaper.isScreenSaverSurface ? saverPlays : shouldPlay
+            play ? wallpaper.renderer.resume() : wallpaper.renderer.pause()
+            wallpaper.setShowingStill(!play)
         }
     }
 

--- a/Muro/Sources/MuroWallpaperExtension/SettingsProvider.swift
+++ b/Muro/Sources/MuroWallpaperExtension/SettingsProvider.swift
@@ -111,14 +111,19 @@ func makeSettingsResponse() -> AnyObject? {
         contextMenu: nil,
         thumbnail: nil
     )
-    let model = SettingsViewModels(
-        desktop: SettingsViewModel(
-            groups: [group],
-            refreshPolicy: .default,
-            isModificationDisabled: false
-        ),
-        screenSaver: nil
+    // The same choices under both roles. `screenSaver` used to be nil, and
+    // that alone is what made a Muro screen saver impossible: before macOS
+    // will render one it asks the provider whether the chosen wallpaper
+    // supports the screen saver, finds nothing here, logs "Screen saver is not
+    // supported for choice …; falling back to system default", and shows
+    // Apple's own instead. It is also what puts Muro in System Settings under
+    // Screen Saver rather than only under Wallpaper.
+    let viewModel = SettingsViewModel(
+        groups: [group],
+        refreshPolicy: .default,
+        isModificationDisabled: false
     )
+    let model = SettingsViewModels(desktop: viewModel, screenSaver: viewModel)
 
     let shim = ShimViewModelsXPC(value: model)
     guard let data = try? NSKeyedArchiver.archivedData(

--- a/Muro/Sources/MuroWallpaperExtension/VideoRenderer.swift
+++ b/Muro/Sources/MuroWallpaperExtension/VideoRenderer.swift
@@ -171,14 +171,21 @@ final class VideoRenderer: @unchecked Sendable {
         }
     }
 
+    /// Strongly, on purpose.
+    ///
+    /// This captured self weakly, and the caller is a surface being taken away:
+    /// it calls stop and then releases the renderer, so the block usually ran
+    /// after the object was already gone and did nothing at all. Nothing at all
+    /// leaves the media-data request armed. See `feedCurrentReader` for what
+    /// that costs. The block releases self as soon as it has run, so holding it
+    /// for the length of one teardown keeps nothing alive.
     func stop() {
-        queue.async { [weak self] in
-            guard let self else { return }
-            isRunning = false
-            renderer.stopRequestingMediaData()
-            currentReader?.cancelReading()
-            nextReader?.cancelReading()
-            displayLayer.removeFromSuperlayer()
+        queue.async {
+            self.isRunning = false
+            self.renderer.stopRequestingMediaData()
+            self.currentReader?.cancelReading()
+            self.nextReader?.cancelReading()
+            self.displayLayer.removeFromSuperlayer()
         }
     }
 
@@ -197,9 +204,19 @@ final class VideoRenderer: @unchecked Sendable {
     }
 
     private func feedCurrentReader() {
-        renderer.requestMediaDataWhenReady(on: queue) { [weak self] in
+        // The renderer is captured weakly beside self, because `self?.renderer`
+        // is nil in the one case that matters. AVFoundation owns this block and
+        // goes on calling it until something calls `stopRequestingMediaData`.
+        // When the surface has gone, self is nil, so `self?.renderer` reached
+        // nothing, the request stayed armed, and the block was called again the
+        // instant it returned. That loop is one CPU core, held for as long as
+        // the extension lives, per surface that was ever taken away. Measured
+        // at 100% of a core each, against 0% for a surface that is simply
+        // sitting there. The video renderer outlives this object, so a weak
+        // handle to it is still something to switch off.
+        renderer.requestMediaDataWhenReady(on: queue) { [weak self, weak armed = self.renderer] in
             guard let self, isRunning else {
-                self?.renderer.stopRequestingMediaData()
+                armed?.stopRequestingMediaData()
                 return
             }
             if renderer.status == .failed {
@@ -223,6 +240,10 @@ final class VideoRenderer: @unchecked Sendable {
     }
 
     private func beginNextLoop() {
+        // A loop step is queued from inside the callback, so it can be waiting
+        // behind a stop. Without this it would arm the request again on a
+        // renderer that has just been switched off.
+        guard isRunning else { return }
         presentationOffset = lastEnqueuedEnd
         if let preparedReader = nextReader, let preparedOutput = nextOutput {
             currentReader = preparedReader

--- a/Muro/Sources/MuroWallpaperExtension/main.swift
+++ b/Muro/Sources/MuroWallpaperExtension/main.swift
@@ -127,6 +127,14 @@ private protocol WallpaperExtensionXPCProtocol {
 }
 
 private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol {
+    override init() {
+        super.init()
+        // The process coming and going is half of every desktop report: a
+        // wallpaper macOS has no running provider for is drawn as the system
+        // default, which reads as the wallpaper having been replaced.
+        extensionLog("extension started pid=\(ProcessInfo.processInfo.processIdentifier)")
+    }
+
     private static let snapshotQueue = DispatchQueue(
         label: "com.mrrockysl.muro.wallpaper-snapshot"
     )
@@ -172,7 +180,9 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
         // because this surface plays.
         let desktopStill = info.isPreview
             ? nil
-            : (info.isScreenSaver ? fallbackStill : (DesktopStill.current() ?? fallbackStill))
+            : (info.isScreenSaver
+                ? fallbackStill
+                : (DesktopStill.current(displayID: info.displayID) ?? fallbackStill))
 
         // The mode is logged because it is what decides still against video,
         // and a lock screen showing the wrong one of the two is answered by
@@ -260,6 +270,7 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
                 // the desktop's picture must not reach across onto it.
                 drawsStill: !info.isPreview && !info.isScreenSaver,
                 isScreenSaverSurface: info.isScreenSaver,
+                displayID: info.displayID,
                 fallback: fallbackStill
             )
             RendererState.shared.install(wallpaper, for: key)

--- a/Muro/Sources/MuroWallpaperExtension/main.swift
+++ b/Muro/Sources/MuroWallpaperExtension/main.swift
@@ -166,7 +166,13 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
         // The fallback is a frame of this wallpaper rather than its thumbnail,
         // because a thumbnail can be missing. See WallpaperFrame.
         let fallbackStill = info.isPreview ? nil : WallpaperFrame.image(for: info.choiceID)
-        let desktopStill = info.isPreview ? nil : (DesktopStill.current() ?? fallbackStill)
+        // The screen saver is not the desktop and must never be handed the
+        // desktop's picture: what belongs behind a screen saver that fails to
+        // decode is a frame of the screen saver. It is only ever a backstop,
+        // because this surface plays.
+        let desktopStill = info.isPreview
+            ? nil
+            : (info.isScreenSaver ? fallbackStill : (DesktopStill.current() ?? fallbackStill))
 
         // The mode is logged because it is what decides still against video,
         // and a lock screen showing the wrong one of the two is answered by
@@ -179,6 +185,7 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
                 + "preview=\(info.isPreview) choice=\(info.choiceID ?? "none") "
                 + "mode=\(info.presentationMode ?? "unset") "
                 + "activity=\(info.activityState ?? "unset") "
+                + "screensaver=\(info.isScreenSaver) "
                 + "covered=\(ScreenState.isCovered()) "
                 + "still=\(info.isPreview ? "n/a" : (desktopStill != nil ? "yes" : "no"))"
         )
@@ -249,7 +256,10 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
                 rootLayer: rootLayer,
                 renderer: renderer,
                 choiceID: info.choiceID,
-                drawsStill: !info.isPreview,
+                // A screen saver keeps the frame it was built with. Restaging
+                // the desktop's picture must not reach across onto it.
+                drawsStill: !info.isPreview && !info.isScreenSaver,
+                isScreenSaverSurface: info.isScreenSaver,
                 fallback: fallbackStill
             )
             RendererState.shared.install(wallpaper, for: key)
@@ -269,11 +279,13 @@ private final class WallpaperXPCHandler: NSObject, WallpaperExtensionXPCProtocol
                     mode: info.presentationMode, activity: info.activityState
                 )
             }
-            let shouldPlay = RendererState.shared.shouldPlayNow(
-                mode: info.presentationMode,
-                activity: info.activityState,
-                isPreview: info.isPreview
-            )
+            let shouldPlay = info.isScreenSaver
+                ? RendererState.shared.shouldScreenSaverPlay()
+                : RendererState.shared.shouldPlayNow(
+                    mode: info.presentationMode,
+                    activity: info.activityState,
+                    isPreview: info.isPreview
+                )
             // Read before the reply closure, which is Sendable and cannot reach
             // into a layer.
             let showingStill = !shouldPlay && desktopStill != nil

--- a/Muro/Tests/MuroKitTests/AppleWallpaperStoreRoleTests.swift
+++ b/Muro/Tests/MuroKitTests/AppleWallpaperStoreRoleTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import MuroKit
+
+/// `holdsRole`, the check an apply needs and did not have.
+///
+/// Built from the exact shape the owner's Mac was in on 2026-09-10: Muro held
+/// the screen saver in `Index2.plist` and Apple's default held it in
+/// `Index.plist`, which is the file macOS reads. The old check asked "is Muro
+/// anywhere in either file", got `true`, and stopped retrying.
+final class AppleWallpaperStoreRoleTests: XCTestCase {
+    let muro = "com.mrrockysl.muro.wallpaper-extension"
+    let apple = "com.apple.wallpaper.choice.default"
+
+    func surface(_ provider: String) -> [String: Any] {
+        ["Content": ["Choices": [["Provider": provider]], "Shuffle": "$null"]]
+    }
+
+    /// One node carrying a desktop and a screen saver, each by whoever is named.
+    func individual(desktop: String, idle: String) -> [String: Any] {
+        ["Type": "individual", "Desktop": surface(desktop), "Idle": surface(idle)]
+    }
+
+    // MARK: The bug
+
+    func testTheFileMacOSReadsIsSeenToBeMissingTheScreenSaver() {
+        let store: Any = [
+            "AllSpacesAndDisplays": individual(desktop: muro, idle: apple),
+            "SystemDefault": individual(desktop: muro, idle: apple),
+        ]
+        // Muro is in the file, so the loose check is happy. That is the trap.
+        XCTAssertTrue(AppleWallpaperStore.containsProvider(muro, in: store))
+        // Asked per role, the truth comes out.
+        XCTAssertFalse(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: "all", surface: .screenSaver)
+        )
+        XCTAssertTrue(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: "all", surface: .desktop)
+        )
+    }
+
+    func testBothRolesHeldReadsAsHeld() {
+        let store: Any = ["AllSpacesAndDisplays": individual(desktop: muro, idle: muro)]
+        XCTAssertTrue(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: "all", surface: .screenSaver)
+        )
+        XCTAssertTrue(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: "all", surface: .desktop)
+        )
+    }
+
+    func testAnEmptyOrUnreadableStoreHoldsNothing() {
+        XCTAssertFalse(
+            AppleWallpaperStore.holdsRole(muro, in: nil, targetKey: "all", surface: .screenSaver)
+        )
+        XCTAssertFalse(
+            AppleWallpaperStore.holdsRole(
+                muro, in: [String: Any](), targetKey: "all", surface: .screenSaver
+            )
+        )
+    }
+
+    // MARK: Node types
+
+    /// A linked node keeps both roles on one key, so holding it holds both.
+    func testALinkedNodeHoldsBothRoles() {
+        let store: Any = ["AllSpacesAndDisplays": ["Type": "linked", "Linked": surface(muro)]]
+        XCTAssertTrue(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: "all", surface: .desktop)
+        )
+        XCTAssertTrue(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: "all", surface: .screenSaver)
+        )
+    }
+
+    /// An `idle` node is the screen saver and has no desktop at all, so it can
+    /// never satisfy the desktop role however it is filled.
+    func testAnIdleNodeNeverSatisfiesTheDesktopRole() {
+        let store: Any = ["AllSpacesAndDisplays": ["Type": "idle", "Idle": surface(muro)]]
+        XCTAssertTrue(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: "all", surface: .screenSaver)
+        )
+        XCTAssertFalse(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: "all", surface: .desktop)
+        )
+    }
+
+    // MARK: Targets
+
+    func testADisplayIsAnsweredByItsOwnNode() {
+        let display = "37D8832A-2D66-02CA-B9F7-8F30A301B230"
+        let other = "C4497200-61AC-4C2C-B727-10348E552634"
+        let store: Any = [
+            "Displays": [
+                display: individual(desktop: muro, idle: muro),
+                other: individual(desktop: apple, idle: apple),
+            ]
+        ]
+        XCTAssertTrue(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: display, surface: .desktop)
+        )
+        XCTAssertFalse(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: other, surface: .desktop)
+        )
+    }
+
+    /// A Mac that has never been given a wallpaper per screen keeps its one
+    /// wallpaper in the shared node, and that node answers for every display.
+    /// Without this a per-display apply would retry forever against a store
+    /// that is already correct.
+    func testASharedNodeAnswersForADisplayWithNoNodeOfItsOwn() {
+        let display = "37D8832A-2D66-02CA-B9F7-8F30A301B230"
+        let store: Any = ["AllSpacesAndDisplays": individual(desktop: muro, idle: muro)]
+        XCTAssertTrue(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: display, surface: .desktop)
+        )
+    }
+
+    func testAnotherDisplaysNodeDoesNotAnswerForThisOne() {
+        let display = "37D8832A-2D66-02CA-B9F7-8F30A301B230"
+        let other = "C4497200-61AC-4C2C-B727-10348E552634"
+        let store: Any = ["Displays": [other: individual(desktop: muro, idle: muro)]]
+        XCTAssertFalse(
+            AppleWallpaperStore.holdsRole(muro, in: store, targetKey: display, surface: .desktop)
+        )
+    }
+}

--- a/Muro/Tests/MuroKitTests/LockScreenSelectionsTests.swift
+++ b/Muro/Tests/MuroKitTests/LockScreenSelectionsTests.swift
@@ -87,3 +87,49 @@ final class LockScreenSelectionsTests: XCTestCase {
         XCTAssertEqual(s.count, 2)
     }
 }
+
+/// The behaviour the owner specified on 2026-09-10, written as a test so the
+/// "one at a time" rule cannot come back by accident. Two displays hold five
+/// wallpapers: a desktop and a lock screen each, plus one screen saver.
+final class TwoDisplayLockScreenSpecTests: XCTestCase {
+    let macBook = "37D8832A-2D66-02CA-B9F7-8F30A301B230"
+    let dell = "C4497200-61AC-4C2C-B727-10348E552634"
+
+    /// C on the MacBook, D on the DELL, E as the screen saver. All three
+    /// survive, and the screen saver is kept in its own record so a lock
+    /// screen apply can never prune its staged file.
+    func testCDandEAllSurvive() {
+        var locks: [String: String] = [:]
+        let connected: Set<String> = [macBook, dell]
+        locks = LockScreenSelections.afterApply(
+            current: locks, targetKey: macBook, wallpaperID: "C", connectedDisplays: connected
+        )
+        locks = LockScreenSelections.afterApply(
+            current: locks, targetKey: dell, wallpaperID: "D", connectedDisplays: connected
+        )
+        let saver = LockScreenSelections.afterApply(
+            current: [:], targetKey: LockScreenSelections.allKey,
+            wallpaperID: "E", connectedDisplays: connected
+        )
+        XCTAssertEqual(locks, [macBook: "C", dell: "D"])
+        XCTAssertEqual(saver, ["all": "E"])
+        // Everything that must stay staged: both lock screens and the saver.
+        let held = Set(locks.values).union(saver.values)
+        XCTAssertEqual(held, ["C", "D", "E"])
+    }
+
+    /// Four displays, same shape: four lock screens plus one screen saver.
+    func testItScalesToFourDisplays() {
+        let ids = (1...4).map { "display-\($0)" }
+        let connected = Set(ids)
+        var locks: [String: String] = [:]
+        for (i, id) in ids.enumerated() {
+            locks = LockScreenSelections.afterApply(
+                current: locks, targetKey: id, wallpaperID: "lock\(i)",
+                connectedDisplays: connected
+            )
+        }
+        XCTAssertEqual(locks.count, 4)
+        XCTAssertEqual(Set(locks.values).count, 4)
+    }
+}

--- a/Muro/Tests/MuroKitTests/LockScreenSelectionsTests.swift
+++ b/Muro/Tests/MuroKitTests/LockScreenSelectionsTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import MuroKit
+
+/// The rule that let one display's lock screen survive another display's apply.
+/// Every case here is the owner's Mac on 2026-09-10: a MacBook and a DELL.
+final class LockScreenSelectionsTests: XCTestCase {
+    let macBook = "37D8832A-2D66-02CA-B9F7-8F30A301B230"
+    let dell = "C4497200-61AC-4C2C-B727-10348E552634"
+    var connected: Set<String> { [macBook, dell] }
+
+    /// The bug. Applying to the second display used to leave only the second.
+    func testASecondDisplayDoesNotThrowAwayTheFirst() {
+        var s = LockScreenSelections.afterApply(
+            current: [:], targetKey: dell, wallpaperID: "rabbit",
+            connectedDisplays: connected
+        )
+        s = LockScreenSelections.afterApply(
+            current: s, targetKey: macBook, wallpaperID: "bus",
+            connectedDisplays: connected
+        )
+        XCTAssertEqual(s, [dell: "rabbit", macBook: "bus"])
+    }
+
+    func testApplyingAgainToOneDisplayReplacesOnlyThatOne() {
+        let s = LockScreenSelections.afterApply(
+            current: [dell: "rabbit", macBook: "bus"],
+            targetKey: macBook, wallpaperID: "forest",
+            connectedDisplays: connected
+        )
+        XCTAssertEqual(s, [dell: "rabbit", macBook: "forest"])
+    }
+
+    /// Every display at once supersedes each of them, so it stands alone.
+    /// This is the case that was already right and must stay that way.
+    func testAllSupersedesEveryPerDisplayChoice() {
+        let s = LockScreenSelections.afterApply(
+            current: [dell: "rabbit", macBook: "bus"],
+            targetKey: LockScreenSelections.allKey, wallpaperID: "snow",
+            connectedDisplays: connected
+        )
+        XCTAssertEqual(s, ["all": "snow"])
+    }
+
+    /// A screen saver apply always carries "all", so its record is unchanged.
+    func testScreenSaverRecordIsUnchanged() {
+        let s = LockScreenSelections.afterApply(
+            current: ["all": "old"],
+            targetKey: LockScreenSelections.allKey, wallpaperID: "new",
+            connectedDisplays: connected
+        )
+        XCTAssertEqual(s, ["all": "new"])
+    }
+
+    /// `all` is kept beside a per-display entry: it is still what a display
+    /// without one of its own is reading, and the desktop still writer asks
+    /// this record before it writes a picture into a display's slot.
+    func testAllSurvivesBesideAPerDisplayChoice() {
+        let s = LockScreenSelections.afterApply(
+            current: ["all": "snow"], targetKey: macBook, wallpaperID: "bus",
+            connectedDisplays: connected
+        )
+        XCTAssertEqual(s, ["all": "snow", macBook: "bus"])
+    }
+
+    /// What stops this growing without limit, which is the reason it was
+    /// written the destructive way in the first place. Every staged wallpaper
+    /// is a row in System Settings.
+    func testADisplayThatIsNoLongerPluggedInIsDropped() {
+        let old = "11111111-2222-3333-4444-555555555555"
+        let s = LockScreenSelections.afterApply(
+            current: [old: "gone", dell: "rabbit"],
+            targetKey: macBook, wallpaperID: "bus",
+            connectedDisplays: connected
+        )
+        XCTAssertEqual(s, [dell: "rabbit", macBook: "bus"])
+        XCTAssertNil(s[old])
+    }
+
+    func testItNeverHoldsMoreThanOnePerConnectedDisplayPlusAll() {
+        var s: [String: String] = [:]
+        for round in 0..<20 {
+            s = LockScreenSelections.afterApply(
+                current: s, targetKey: round.isMultiple(of: 2) ? macBook : dell,
+                wallpaperID: "w\(round)", connectedDisplays: connected
+            )
+        }
+        XCTAssertEqual(s.count, 2)
+    }
+}

--- a/Muro/Tests/MuroKitTests/ScreenSaverDelayTests.swift
+++ b/Muro/Tests/MuroKitTests/ScreenSaverDelayTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import MuroKit
+
+/// The list and the wording only. Nothing here reads or writes the real
+/// preference: these tests run on the owner's own Mac, and a test that set
+/// `idleTime` would change when his screen saver starts as a side effect of
+/// running the suite.
+final class ScreenSaverDelayTests: XCTestCase {
+
+    // MARK: The list
+
+    func testTheChoicesAreApplesOwnList() {
+        XCTAssertEqual(ScreenSaverDelay.choices, [
+            60,     // After 1 minute
+            120,    // After 2 minutes
+            180,    // After 3 minutes
+            300,    // After 5 minutes
+            600,    // After 10 minutes
+            1200,   // After 20 minutes
+            1800,   // After 30 minutes
+            3600,   // After 1 hour
+            5400,   // After 1 hour, 30 minutes
+            7200,   // After 2 hours
+            9000,   // After 2 hours, 30 minutes
+            10800,  // After 3 hours
+            0,      // Never
+        ])
+    }
+
+    func testNeverIsLastSoTheDestructiveChoiceIsNotInTheMiddleOfTheDurations() {
+        XCTAssertEqual(ScreenSaverDelay.choices.last, ScreenSaverDelay.never)
+    }
+
+    /// `never` has to stay below the one-second guard in loginwindow's
+    /// `_checkUserIdleDuringReset:`. Raise it above that and "Never" quietly
+    /// becomes "almost immediately".
+    func testNeverIsBelowTheOneSecondGuardThatMakesItWork() {
+        XCTAssertLessThan(ScreenSaverDelay.never, 1)
+    }
+
+    func testTheDurationsRiseAndNoneRepeat() {
+        let durations = ScreenSaverDelay.choices.filter { $0 > 0 }
+        XCTAssertEqual(durations, durations.sorted())
+        XCTAssertEqual(Set(durations).count, durations.count)
+    }
+
+    // MARK: The wording
+
+    func testMinutesReadAsMinutes() {
+        XCTAssertEqual(ScreenSaverDelay.label(60), "1 min")
+        XCTAssertEqual(ScreenSaverDelay.label(300), "5 min")
+        XCTAssertEqual(ScreenSaverDelay.label(1800), "30 min")
+    }
+
+    func testHoursReadAsHours() {
+        XCTAssertEqual(ScreenSaverDelay.label(3600), "1 h")
+        XCTAssertEqual(ScreenSaverDelay.label(5400), "1 h 30 min")
+        XCTAssertEqual(ScreenSaverDelay.label(9000), "2 h 30 min")
+        XCTAssertEqual(ScreenSaverDelay.label(10800), "3 h")
+    }
+
+    func testZeroReadsAsNever() {
+        XCTAssertEqual(ScreenSaverDelay.label(ScreenSaverDelay.never), "Never")
+    }
+
+    /// Nothing Muro writes is negative, but Apple's key is a plain integer
+    /// anyone can put anything in, and a negative one is still a target below
+    /// the guard, so it means the same thing.
+    func testANegativeValueAlsoReadsAsNever() {
+        XCTAssertEqual(ScreenSaverDelay.label(-30), "Never")
+    }
+
+    func testAnAbsentPreferenceSaysSoRatherThanNamingADurationMuroDoesNotKnow() {
+        XCTAssertEqual(ScreenSaverDelay.label(nil), "System default")
+    }
+
+    /// A value set by hand, or by an older macOS, still has to render.
+    func testAValueOutsideTheListStillReads() {
+        XCTAssertEqual(ScreenSaverDelay.label(45), "45 s")
+        XCTAssertEqual(ScreenSaverDelay.label(2700), "45 min")
+    }
+
+    func testEveryChoiceHasALabel() {
+        for seconds in ScreenSaverDelay.choices {
+            XCTAssertFalse(ScreenSaverDelay.label(seconds).isEmpty)
+        }
+    }
+}

--- a/Muro/Tests/MuroKitTests/ScreenSaverSurfaceTests.swift
+++ b/Muro/Tests/MuroKitTests/ScreenSaverSurfaceTests.swift
@@ -1,0 +1,257 @@
+import XCTest
+@testable import MuroKit
+
+/// Issue #18: the screen saver.
+///
+/// The screen saver is Apple's `Idle` key, which is a different key from the
+/// one the lock screen renders. Everything here is about keeping those two
+/// apart: setting one must not disturb the other, and removing one must not
+/// take the other with it. The exception is a `linked` node, where macOS
+/// itself keeps both on one key, and that is asserted rather than worked
+/// around.
+///
+/// Like `AppleWallpaperStoreTests`, none of the linked shapes can be produced
+/// on the machine this was written on, so the assertions are the proof.
+final class ScreenSaverSurfaceTests: XCTestCase {
+    private let muro = "com.mrrockysl.muro.wallpaper-extension"
+
+    private func choice(_ id: String) -> [String: Any] {
+        [
+            "Provider": muro,
+            "Files": [["relative": "file:///v/\(id).mov"]],
+            "Configuration": Data(id.utf8),
+        ]
+    }
+
+    private func surface(provider: String) -> [String: Any] {
+        ["Content": ["Choices": [["Provider": provider]], "Shuffle": "$null"]]
+    }
+
+    private func providers(_ store: Any, _ path: [String], _ key: String) -> [String] {
+        var current = store
+        for component in path {
+            guard let dictionary = current as? [String: Any],
+                  let next = dictionary[component]
+            else { return [] }
+            current = next
+        }
+        guard let node = current as? [String: Any],
+              let surface = node[key] as? [String: Any]
+        else { return [] }
+        return AppleWallpaperStore.providers(of: surface)
+    }
+
+    private func apply(
+        _ id: String,
+        _ role: AppleWallpaperStore.Surface,
+        to store: inout Any,
+        target: String = "all"
+    ) {
+        AppleWallpaperStore.applyChoiceCreatingNode(
+            choice(id),
+            to: &store,
+            targetKey: target,
+            surface: role,
+            desktopFallback: surface(provider: "apple.desktop"),
+            idleFallback: surface(provider: "apple.idle")
+        )
+    }
+
+    // MARK: - Which key each role lands on
+
+    func testTheScreenSaverIsIdleOnAnIndividualNode() {
+        let node: [String: Any] = ["Type": "individual"]
+        XCTAssertEqual(AppleWallpaperStore.surfaceName(of: node, for: .screenSaver), "Idle")
+        XCTAssertEqual(AppleWallpaperStore.surfaceName(of: node, for: .desktop), "Desktop")
+    }
+
+    /// A linked Mac keeps one wallpaper for both. That is what linking means,
+    /// so both roles answer with the same key rather than one of them failing.
+    func testALinkedNodeGivesBothRolesTheSameKey() {
+        let node: [String: Any] = ["Type": "linked"]
+        XCTAssertEqual(AppleWallpaperStore.surfaceName(of: node, for: .desktop), "Linked")
+        XCTAssertEqual(AppleWallpaperStore.surfaceName(of: node, for: .screenSaver), "Linked")
+    }
+
+    /// A screen-saver-only node has nowhere to put a desktop, and that has not
+    /// changed. It is now a perfectly good home for a screen saver.
+    func testAnIdleOnlyNodeTakesTheScreenSaverButNotTheDesktop() {
+        let node: [String: Any] = ["Type": "idle"]
+        XCTAssertNil(AppleWallpaperStore.surfaceName(of: node, for: .desktop))
+        XCTAssertEqual(AppleWallpaperStore.surfaceName(of: node, for: .screenSaver), "Idle")
+    }
+
+    func testTheDesktopShorthandStillAnswersExactlyAsBefore() {
+        for type in ["linked", "individual", "desktop", "idle"] {
+            let node: [String: Any] = ["Type": type]
+            XCTAssertEqual(
+                AppleWallpaperStore.desktopSurfaceName(of: node),
+                AppleWallpaperStore.surfaceName(of: node, for: .desktop),
+                "the shorthand drifted from the rule for \(type)"
+            )
+        }
+    }
+
+    // MARK: - Setting one does not disturb the other
+
+    func testTheScreenSaverGoesToIdleAndLeavesTheLockScreenAlone() {
+        var store: Any = [
+            "AllSpacesAndDisplays": [
+                "Type": "individual",
+                "Desktop": surface(provider: muro),
+                "Idle": surface(provider: "apple.idle"),
+            ],
+        ]
+        apply("saver", .screenSaver, to: &store)
+
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Idle"), [muro])
+        XCTAssertEqual(
+            providers(store, ["AllSpacesAndDisplays"], "Desktop"), [muro],
+            "the lock screen's own key must be untouched"
+        )
+    }
+
+    func testSettingTheLockScreenLeavesAnAppliedScreenSaverAlone() {
+        var store: Any = [
+            "AllSpacesAndDisplays": [
+                "Type": "individual",
+                "Desktop": surface(provider: "apple.desktop"),
+                "Idle": surface(provider: muro),
+            ],
+        ]
+        apply("lock", .desktop, to: &store)
+
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Desktop"), [muro])
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Idle"), [muro])
+    }
+
+    /// Both roles on one Mac, applied one after the other, is the case a user
+    /// reaches by picking "All".
+    func testBothRolesCanBeMuroAtOnce() {
+        var store: Any = [
+            "AllSpacesAndDisplays": [
+                "Type": "individual",
+                "Desktop": surface(provider: "apple.desktop"),
+                "Idle": surface(provider: "apple.idle"),
+            ],
+        ]
+        apply("one", .desktop, to: &store)
+        apply("one", .screenSaver, to: &store)
+
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Desktop"), [muro])
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Idle"), [muro])
+        XCTAssertTrue(AppleWallpaperStore.containsProvider(muro, in: store))
+    }
+
+    // MARK: - Nodes that have never had a screen saver
+
+    /// A node typed `desktop` has no `Idle` at all. It gains one, and it says
+    /// so: a node carrying both keys is an individual one, and leaving `Type`
+    /// on `desktop` would describe a shape it no longer has.
+    func testADesktopOnlyNodeGainsAnIdleAndSaysSo() {
+        var store: Any = [
+            "AllSpacesAndDisplays": [
+                "Type": "desktop",
+                "Desktop": surface(provider: "apple.desktop"),
+            ],
+        ]
+        apply("saver", .screenSaver, to: &store)
+
+        let node = (store as? [String: Any])?["AllSpacesAndDisplays"] as? [String: Any]
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Idle"), [muro])
+        XCTAssertEqual(node?["Type"] as? String, "individual")
+        XCTAssertTrue(AppleWallpaperStore.isWellFormed(node ?? [:]))
+    }
+
+    /// An untyped node is left untyped. Nothing recorded how that Mac is
+    /// arranged, so nothing may claim to.
+    func testAnUntypedNodeGainsAnIdleWithoutGainingAType() {
+        var store: Any = [
+            "AllSpacesAndDisplays": ["Desktop": surface(provider: "apple.desktop")],
+        ]
+        apply("saver", .screenSaver, to: &store)
+
+        let node = (store as? [String: Any])?["AllSpacesAndDisplays"] as? [String: Any]
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Idle"), [muro])
+        XCTAssertNil(node?["Type"])
+    }
+
+    /// A store with no node at all still gets one, and it is well formed: the
+    /// screen saver is ours and the desktop is left to the system.
+    func testAnEmptyStoreGetsAWellFormedScreenSaverNode() {
+        var store: Any = [String: Any]()
+        apply("saver", .screenSaver, to: &store)
+
+        let node = (store as? [String: Any])?["AllSpacesAndDisplays"] as? [String: Any]
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Idle"), [muro])
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Desktop"), ["apple.desktop"])
+        XCTAssertEqual(node?["Type"] as? String, "individual")
+        XCTAssertTrue(AppleWallpaperStore.isWellFormed(node ?? [:]))
+    }
+
+    // MARK: - The linked Mac from issue #11
+
+    /// On a linked Mac the screen saver lands on `Linked`, which is also the
+    /// desktop. There is no second key to write and inventing one would put
+    /// the wallpaper where macOS never looks, which is the whole of #11.
+    func testOnALinkedMacTheScreenSaverWritesLinked() {
+        var store: Any = [
+            "AllSpacesAndDisplays": ["Type": "linked", "Linked": surface(provider: "apple")],
+        ]
+        apply("saver", .screenSaver, to: &store)
+
+        XCTAssertEqual(providers(store, ["AllSpacesAndDisplays"], "Linked"), [muro])
+        let node = (store as? [String: Any])?["AllSpacesAndDisplays"] as? [String: Any]
+        XCTAssertNil(node?["Idle"], "a linked node must not grow a second key")
+        XCTAssertEqual(node?["Type"] as? String, "linked", "the user's arrangement is not ours")
+    }
+
+    // MARK: - Targets and repeats
+
+    func testASingleDisplayScreenSaverLeavesTheOtherDisplayAlone() {
+        var store: Any = [
+            "Displays": [
+                "AAA": [
+                    "Type": "individual",
+                    "Desktop": surface(provider: "apple.desktop"),
+                    "Idle": surface(provider: "apple.idle"),
+                ],
+                "BBB": [
+                    "Type": "individual",
+                    "Desktop": surface(provider: "apple.desktop"),
+                    "Idle": surface(provider: "apple.idle"),
+                ],
+            ],
+        ]
+        apply("saver", .screenSaver, to: &store, target: "AAA")
+
+        XCTAssertEqual(providers(store, ["Displays", "AAA"], "Idle"), [muro])
+        XCTAssertEqual(providers(store, ["Displays", "BBB"], "Idle"), ["apple.idle"])
+    }
+
+    func testApplyingTheScreenSaverTwiceIsStable() {
+        var first: Any = [
+            "AllSpacesAndDisplays": [
+                "Type": "individual",
+                "Desktop": surface(provider: "apple.desktop"),
+                "Idle": surface(provider: "apple.idle"),
+            ],
+        ]
+        apply("saver", .screenSaver, to: &first)
+        var second = first
+        apply("saver", .screenSaver, to: &second)
+
+        XCTAssertEqual(providers(second, ["AllSpacesAndDisplays"], "Idle"), [muro])
+        let node = (second as? [String: Any])?["AllSpacesAndDisplays"] as? [String: Any]
+        XCTAssertTrue(AppleWallpaperStore.isWellFormed(node ?? [:]))
+    }
+
+    func testEmptyAndOddInputsDoNotCrash() {
+        var nothing: Any = [String: Any]()
+        apply("saver", .screenSaver, to: &nothing, target: "AAA")
+        var junk: Any = ["Displays": "not a dictionary"]
+        apply("saver", .screenSaver, to: &junk)
+        var nested: Any = ["A": ["B": ["C": [String: Any]()]]]
+        apply("saver", .screenSaver, to: &nested)
+    }
+}

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="15"
+BUILD="16"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="16"
+BUILD="17"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="22"
+BUILD="23"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="23"
+BUILD="24"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="10"
+BUILD="11"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"
@@ -20,13 +20,29 @@ APP="$DIR/dist/Muro.app"
 # later change reaches both without a second thought. The wallpaper
 # extension carries the same two architectures, set in its Xcode project.
 echo "==> swift build -c release (universal: arm64 + x86_64)"
-swift build -c release --package-path "$DIR" --arch arm64 --arch x86_64
+SWIFT_BUILD_FLAGS=(-c release --package-path "$DIR" --arch arm64 --arch x86_64)
+swift build "${SWIFT_BUILD_FLAGS[@]}"
+
+# Ask SwiftPM where it put the binary rather than assuming `.build/release`.
+#
+# That name is a symlink SwiftPM maintains, and a universal build does not
+# write through it: it builds into `.build/apple/Products/Release` while the
+# symlink can still point at a scratch path some earlier build used. On
+# 2026-09-10 this shipped a two day old app on top of a freshly built
+# extension, silently, with the build reporting success throughout. A stale
+# binary is the one build failure that looks exactly like a working build, so
+# the path is asked for and the copy is checked.
+BIN_PATH="$(swift build "${SWIFT_BUILD_FLAGS[@]}" --show-bin-path)"
+if [[ ! -f "$BIN_PATH/muro-app" ]]; then
+    echo "ERROR: no muro-app in $BIN_PATH" >&2
+    exit 1
+fi
 
 echo "==> assembling $APP"
 rm -rf "$DIR/dist"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
 
-cp "$DIR/.build/release/muro-app" "$APP/Contents/MacOS/Muro"
+cp "$BIN_PATH/muro-app" "$APP/Contents/MacOS/Muro"
 
 # macOS 26+ lock-screen renderer. Build it as a real ExtensionKit target so
 # ExtensionFoundation installs the correct entry point and actor isolation.

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="11"
+BUILD="12"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="12"
+BUILD="13"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="13"
+BUILD="14"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="17"
+BUILD="21"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="14"
+BUILD="15"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -8,8 +8,8 @@ set -e
 # The one place Muro's version is written. The app bundle, the wallpaper
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
-VERSION="4.0.2"
-BUILD="24"
+VERSION="4.0.3"
+BUILD="25"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/Muro/build-app.sh
+++ b/Muro/build-app.sh
@@ -9,7 +9,7 @@ set -e
 # extension and the DMG name are all derived from these two lines, and the
 # build fails below if the app and the extension ever disagree.
 VERSION="4.0.2"
-BUILD="21"
+BUILD="22"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 APP="$DIR/dist/Muro.app"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,7 @@ The main app uses normal user-level access to:
 - Observe display sleep, screen lock, its wallpaper windows' visibility, and
   power state
 - Register Muro as a login item only when you enable **Launch at Login**
+- Set your Mac's screen saver, and how long it waits, when you ask it to
 
 Imported videos stay on your Mac and are not uploaded.
 
@@ -129,6 +130,31 @@ This feature depends on private macOS wallpaper interfaces, including
 `WallpaperExtensionKit` and runtime-only wallpaper types. Apple can change these
 interfaces without notice, so future macOS releases may require compatibility
 fixes.
+
+### Screen saver
+
+Since 4.0.3, Muro can be your screen saver as well as your desktop and lock
+screen. macOS keeps all three in the same user-level wallpaper stores, and it
+files the screen saver under a role it calls `idle`, so applying one writes the
+same `Index.plist` and `Index2.plist` described above and takes the same backups
+first. The screen saver is one setting for the whole Mac rather than one per
+display, because macOS has no per-display screen saver.
+
+Muro checks at launch that it still holds the screen saver it recorded, and puts
+it back if macOS has given it to something else. That check exists because
+replacing **Muro.app** while Muro is running makes macOS drop the wallpaper
+extension and hand the screen saver to Apple's aerials, and macOS does not hand
+it back on its own.
+
+Settings has a **Start Screen Saver** row that sets how long your Mac waits
+before the screen saver begins. It writes the key `idleTime` in the
+`com.apple.screensaver` preferences domain, for the current user and the current
+host, which is the single place macOS keeps that setting and the same place
+System Settings writes it. This is disclosed because that preference is state
+outside Muro's own data directories. Muro writes only that one key, only when
+you change that row, and it writes **Never** as `0`, which is how macOS itself
+records it. No other key, domain, user or host is touched, and nothing is read
+from or written to the preference unless you open Settings.
 
 ### Network access
 
@@ -217,7 +243,7 @@ You can inspect and compile the tagged source:
 ```bash
 git clone https://github.com/MrRockySL/Muro.git
 cd Muro
-git checkout v4.0
+git checkout v4.0.3
 swift build -c release --package-path Muro
 ```
 


### PR DESCRIPTION
Raised in #18.

Muro sets the desktop and the lock screen. This adds the third surface, the screen saver, and it plays video rather than showing a still frame.

## The screen saver

macOS files the screen saver under a role it calls `idle`, and `idle` **is** the screen saver, not the lock screen. `WallpaperPresentationMode` has exactly `default`, `locked` and `idle`, and a creation request carries no content type at all, so the mode is the only signal there is. The extension was answering `false` to `idle`, which is why it never played.

It is also one setting for the whole Mac rather than one per display. It lives under `AllSpacesAndDisplays`, which carries no display name, so a per-display apply wrote every node except the only one macOS reads. The apply card gives it a single card now instead of one per screen.

## When it starts

Settings, Playback, **Start Screen Saver**, with Apple's own list and Never. It writes `idleTime` in `com.apple.screensaver`, current user and current host, which is the single place macOS keeps it and the same place System Settings writes it.

macOS reads that preference only when its own idle timer fires or on a screen lock, and it arms that timer for the full delay, so a change is adopted at the next idle check rather than instantly. Apple's own panel behaves identically, its binary calls `CFPreferencesSetValue` and posts no notification. Locking and unlocking ends the wait immediately. The row says so after a change.

## Fixed on the way

- **A removed wallpaper surface left a CPU core spinning**, with Muro closed and nothing on screen. `VideoRenderer.stop()` captured self weakly and its only caller released the renderer straight after, so the block usually ran against nothing and left AVFoundation's media-data request armed forever. Measured at 100% per removed surface before the fix, 0.0% after.
- **A lock screen on every display, not just the last one applied.** A launch enforced an older one-lock-screen rule and threw the other away, and the prune took the screen saver with it.
- **The desktop was one picture for the whole Mac.** It is a still per display now, named with the display id macOS itself puts in the acquire request.
- **The desktop came back as Apple's default on a second quit.** Launching Muro makes macOS drop the wallpaper extension, and it does not reconnect on its own for up to a minute. The gap is closed at launch now, where nobody can be looking at the desktop.
- **Installing Muro over a running Muro handed the screen saver to Apple's aerials.** macOS logs "Wallpaper extension was removed" the second the bundle is replaced, resolves the screen saver to its own aerials, and never hands it back. Launch now checks Muro still holds what it recorded and puts it back if it does not.
- **Open Muro and Settings did nothing from the menu bar after a start at login.** SwiftUI builds a window scene's `NSWindow` the first time that window is shown, so a launch that never shows it has no window to front and had not yet registered the Settings opener.

## Also

The apply card is narrower, its buttons are one size and its tabs no longer wrap. SECURITY.md documents the two things the screen saver writes outside Muro's own data directories. The build asks SwiftPM where it put the binary rather than assuming `.build/release`, which once shipped a two day old app under a freshly built extension with the build reporting success throughout.

177 tests, 0 failures. Universal, app and extension both 4.0.3 (25).
