### PR TITLE
Let the menu bar icon stay off when Muro starts at login

### DIFF
--- a/Muro/Sources/MuroApp/SettingsView.swift
+++ b/Muro/Sources/MuroApp/SettingsView.swift
@@ -50,14 +50,11 @@ struct SettingsView: View {
                             .labelsHidden()
                             .onChange(of: launchAtLogin) { _, enabled in
                                 setLaunchAtLogin(enabled)
-                                // Logging in with no menu bar icon would leave
-                                // no way to reach the app — keep them together.
-                                if enabled { showMenuBarIcon = true }
                             }
                     }
                     divider
                     row(icon: "menubar.rectangle", tint: .purple, title: "Show Menu Bar Icon",
-                        subtitle: "Quick controls from the menu bar") {
+                        subtitle: menuBarSubtitle) {
                         Toggle("", isOn: $showMenuBarIcon)
                             .toggleStyle(.switch)
                             .tint(Color.muroAccent)
@@ -475,6 +472,23 @@ struct SettingsView: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 5.5)
             .glassCapsule(fill: 0.09, stroke: 0.15)
+    }
+
+    /// What the menu bar row says underneath itself.
+    ///
+    /// Turning Launch at Login on used to switch the menu bar icon back on,
+    /// because at the time the icon really was the only way back into a
+    /// running Muro. `applicationShouldHandleReopen` fixed that: Launchpad,
+    /// Spotlight and Finder all reopen the gallery now. The force outlived its
+    /// reason and took the choice away from exactly the people who want Muro
+    /// out of the way, which is issue #31.
+    ///
+    /// So it is gone, and the row says where Muro is instead, on the one
+    /// combination where nothing on screen leads back to it.
+    private var menuBarSubtitle: String {
+        showMenuBarIcon || showDockIcon
+            ? "Quick controls from the menu bar"
+            : "Open Muro from Launchpad or Spotlight"
     }
 
     private func row(


### PR DESCRIPTION
Raised in #31.

The setting to hide the menu bar icon already existed. Turning on Launch at Login switched it straight back on, which is the exact combination that issue asks for: Muro running quietly in the background with no icon in the menu bar.

That force was written when the menu bar icon really was the only way back into a running Muro. The gallery window is ordered out rather than closed, so clicking the app did nothing at all. `applicationShouldHandleReopen` fixed that later, and Launchpad, Spotlight and Finder all reopen the gallery now, so the force outlived its reason and went on taking the choice away from the people who deliberately want Muro out of the way.

With the Dock icon switched off as well, nothing on screen leads back to Muro. Rather than overriding a switch that was just set, the row says where Muro is instead:

> **Show Menu Bar Icon**
> Open Muro from Launchpad or Spotlight

One line removed, one computed subtitle added. 177 tests, 0 failures.
