### PR TITLE
Let any wallpaper be liked, downloaded or not

### DIFF
--- a/Muro/Sources/MuroApp/Components.swift
+++ b/Muro/Sources/MuroApp/Components.swift
@@ -785,8 +785,6 @@ struct HeartButton: View {
                 .background(Circle().fill(Color.black.opacity(0.4)))
         }
         .buttonStyle(.plain)
-        .disabled(!item.isDownloaded)
-        .opacity(item.isDownloaded || item.liked ? 1 : 0.4)
     }
 }
 
@@ -996,7 +994,7 @@ struct WallpaperCard: View {
             SelectionTick(isSelected: isSelected).padding(12)
         } else if item.liked {
             HeartButton(item: item).padding(12)
-        } else if hovering && item.isDownloaded {
+        } else if hovering {
             HeartButton(item: item).padding(12).transition(Self.popIn)
         }
     }

--- a/Muro/Sources/MuroApp/LibraryView.swift
+++ b/Muro/Sources/MuroApp/LibraryView.swift
@@ -5,8 +5,13 @@ import MuroKit
 struct LibraryView: View {
     @EnvironmentObject var store: AppStore
 
+    /// `all` is named for the tab it has always been rather than what it holds,
+    /// and what it holds is the downloads. It reads "Downloaded" since likes
+    /// stopped needing one: Liked now lists the catalog too, so the tab beside
+    /// it was the narrower of the two while calling itself All.
     enum LibTab: String, CaseIterable {
-        case all = "All", liked = "Liked", playlists = "Playlists", automations = "Automations"
+        case all = "Downloaded", liked = "Liked"
+        case playlists = "Playlists", automations = "Automations"
     }
 
     @State private var tab: LibTab = .all
@@ -35,12 +40,26 @@ struct LibraryView: View {
         GridItem(.flexible(), spacing: 24)
     ]
 
+    private func matchesSearch(_ item: WallpaperItem) -> Bool {
+        store.searchText.isEmpty
+            || item.title.localizedCaseInsensitiveContains(store.searchText)
+            || item.category.localizedCaseInsensitiveContains(store.searchText)
+    }
+
     private var searched: [WallpaperItem] {
-        store.localItems.filter { item in
-            store.searchText.isEmpty
-                || item.title.localizedCaseInsensitiveContains(store.searchText)
-                || item.category.localizedCaseInsensitiveContains(store.searchText)
-        }
+        store.localItems.filter(matchesSearch)
+    }
+
+    /// Liked is the one tab that is not about what is on this Mac. A heart can
+    /// be put on any wallpaper in the catalog, so it lists downloads and
+    /// catalog entries together, or a wallpaper liked in Explore would
+    /// disappear the moment it was liked.
+    ///
+    /// Select mode is the exception. The only thing it does is delete, and
+    /// there is nothing to delete on a wallpaper that was never downloaded, so
+    /// while it is on the tab shows what it can act on.
+    private var likedGridItems: [WallpaperItem] {
+        selecting ? visibleItems : store.likedItems.filter(matchesSearch)
     }
 
     var body: some View {
@@ -58,7 +77,7 @@ struct LibraryView: View {
                                 if !selecting { dropZone }
                                 grid(items: searched)
                             case .liked:
-                                grid(items: searched.filter(\.liked))
+                                grid(items: likedGridItems)
                             case .playlists:
                                 playlistsGrid
                             case .automations:
@@ -119,7 +138,7 @@ struct LibraryView: View {
         ZStack {
             PillSegments(
                 options: [
-                    PillOption(LibTab.all.rawValue, "All", count: store.localItems.count),
+                    PillOption(LibTab.all.rawValue, "Downloaded", count: store.localItems.count),
                     PillOption(LibTab.liked.rawValue, "Liked", count: store.likedItems.count),
                     PillOption(LibTab.playlists.rawValue, "Playlists", count: store.playlists.count),
                     PillOption(LibTab.automations.rawValue, "Automations", count: store.automations.count)

--- a/Muro/Sources/MuroApp/Store.swift
+++ b/Muro/Sources/MuroApp/Store.swift
@@ -18,7 +18,11 @@ struct WallpaperItem: Identifiable, Equatable {
     var fps: Double { local?.fps ?? remote?.fps ?? 30 }
     var duration: Double { local?.duration ?? remote?.duration ?? 0 }
     var sizeBytes: Int64 { local?.sizeBytes ?? remote?.sizeBytes ?? 0 }
-    var liked: Bool { local?.liked ?? false }
+    /// Set from `AppStore.likedIDs` when the item is built, not read out of
+    /// the library entry. A like has to work on a wallpaper that has never
+    /// been downloaded, and an undownloaded one has no library entry to
+    /// carry the flag. See `AppStore.likedIDs`.
+    var liked: Bool = false
     var isDownloaded: Bool { local != nil }
     var resolutionLabel: String {
         width >= 3200 ? "4K" : (width >= 2200 ? "1440p" : "1080p")
@@ -438,11 +442,16 @@ final class AppStore: ObservableObject {
         var seen = Set<String>()
         var out: [WallpaperItem] = []
         out.reserveCapacity(manifest.wallpapers.count + catalog.count)
+        let liked = likedIDs
         for entry in manifest.wallpapers where seen.insert(entry.id).inserted {
-            out.append(WallpaperItem(local: entry, remote: remoteByID[entry.id]))
+            out.append(WallpaperItem(
+                local: entry, remote: remoteByID[entry.id], liked: liked.contains(entry.id)
+            ))
         }
         for remote in catalog where !seen.contains(remote.id) {
-            out.append(WallpaperItem(local: nil, remote: remote))
+            out.append(WallpaperItem(
+                local: nil, remote: remote, liked: liked.contains(remote.id)
+            ))
         }
         cachedItems = out
         return out
@@ -592,7 +601,9 @@ final class AppStore: ObservableObject {
         }
         if let firstLocal = localItems.first { return firstLocal }
         if let bundled = item(id: BundledWallpaper.id) { return bundled }
-        return BundledWallpaper.fallbackEntry.map { WallpaperItem(local: nil, remote: $0) }
+        return BundledWallpaper.fallbackEntry.map {
+            WallpaperItem(local: nil, remote: $0, liked: likedIDs.contains($0.id))
+        }
     }
 
     func heroPlayable(_ item: WallpaperItem) -> Bool {
@@ -608,7 +619,10 @@ final class AppStore: ObservableObject {
             if let bundled = item(id: BundledWallpaper.id) {
                 out.insert(bundled, at: 0)
             } else if let entry = BundledWallpaper.fallbackEntry {
-                out.insert(WallpaperItem(local: nil, remote: entry), at: 0)
+                out.insert(
+                    WallpaperItem(local: nil, remote: entry, liked: likedIDs.contains(entry.id)),
+                    at: 0
+                )
             }
         }
         return out
@@ -641,6 +655,7 @@ final class AppStore: ObservableObject {
             // right before it made it true.
             libraryUnreadable = true
         }
+        loadLikes()
         config = EngineConfig.load(root: root)
         playlists = PlaylistStore.load(root: root)
         automations = AutomationStore.load(root: root)
@@ -1331,16 +1346,42 @@ final class AppStore: ObservableObject {
 
     // MARK: - Likes
 
-    /// Saving the in-memory manifest would write back whatever this copy was
-    /// last loaded with, so a download that finished in the meantime would be
-    /// erased by a heart tap. Every manifest edit goes through LibraryWriter,
-    /// which works from what is actually on disk.
-    func toggleLike(_ item: WallpaperItem) {
-        write { manifest in
-            guard let index = manifest.wallpapers.firstIndex(where: { $0.id == item.id })
-            else { return }
-            manifest.wallpapers[index].liked.toggle()
+    /// Every wallpaper this install has liked, downloaded or not.
+    ///
+    /// Likes used to be a flag inside `library.json`, and that file only holds
+    /// wallpapers that have actually been downloaded. So the heart was switched
+    /// off on everything else, and the only wallpapers anyone could like were
+    /// the ones they already had, which is issue #30. A like says "I want this
+    /// one", which is a thing to say before a download rather than after it, so
+    /// the ids live in UserDefaults instead, the same way `seenCatalogIDs`
+    /// does, and cover the whole catalog.
+    private(set) var likedIDs: Set<String> = []
+
+    /// Likes made by an older build sit in the manifest. They are folded in
+    /// once so nobody opens this version and finds an empty Liked tab. The
+    /// manifest flag is left alone: an older build reading the same library
+    /// still works, and folding the same ids in again changes nothing.
+    private func loadLikes() {
+        var ids = Set(defaults.stringArray(forKey: "likedIDs") ?? [])
+        let fromManifest = Set(manifest.wallpapers.filter(\.liked).map(\.id))
+        if !fromManifest.isSubset(of: ids) {
+            ids.formUnion(fromManifest)
+            defaults.set(Array(ids), forKey: "likedIDs")
         }
+        guard ids != likedIDs else { return }
+        likedIDs = ids
+        invalidateItemCache()
+    }
+
+    func toggleLike(_ item: WallpaperItem) {
+        objectWillChange.send()
+        if likedIDs.contains(item.id) {
+            likedIDs.remove(item.id)
+        } else {
+            likedIDs.insert(item.id)
+        }
+        defaults.set(Array(likedIDs), forKey: "likedIDs")
+        invalidateItemCache()
     }
 
     /// Every small manifest edit the interface makes, in one place.


### PR DESCRIPTION
Raised in #30.

The heart only worked on wallpapers that were already downloaded, so once you liked the one you had, every other heart was greyed out.

Likes were kept as a flag inside `library.json`, and that file only has entries for wallpapers that are actually on the Mac, so a catalog wallpaper had nothing to carry the flag. I moved the liked ids out into UserDefaults, beside `seenCatalogIDs`, so they cover the whole catalog, survive a delete, and no longer write the library file at all.

The Liked tab moved with them. It read the downloaded list, so a wallpaper liked in Explore would have disappeared the moment it was liked. It reads the library and the catalog together now. Select mode is the exception and still lists downloads only, because the only thing it does is delete.

Likes made by an older build are read out of the manifest once and folded in, so nobody opens this build to an empty Liked tab. The manifest flag is left where it is, so an older build sharing the same library keeps working.

I also renamed the first library tab from All to Downloaded. It only ever listed what is on this Mac, and with Liked now carrying the catalog too it had become the narrower of the two while calling itself All. The drop zone for importing a video stays in it.

177 tests pass. Built and checked on macOS 26.6.2.
