### PR TITLE
Play only on a clear desktop, and replay Pause After when it clears

### DIFF
--- a/Muro/Sources/MuroApp/PreviewView.swift
+++ b/Muro/Sources/MuroApp/PreviewView.swift
@@ -231,6 +231,10 @@ struct PreviewView: View {
     private func pauseAfterPill(_ item: WallpaperItem) -> some View {
         let value = store.effectivePauseAfter(for: item)
         let overridden = store.hasPauseAfterOverride(item)
+        // Shorter than the list in Settings on purpose: this menu opens over
+        // the wallpaper itself, and any other time is one step away under
+        // Custom. 0 is Never pause.
+        let choices = [0, 10, 30, 60, 300, 3600]
         // Centred on the pill: it sits in the middle of the bottom bar, so a
         // menu hanging off either edge of it looks like a mistake.
         return GlassDropdown(width: 190, arrowEdge: .top, align: .center, options: {
@@ -238,15 +242,20 @@ struct PreviewView: View {
                         checked: !overridden) {
                 store.setPauseAfter(nil, for: item)
             }, .divider]
-            + SettingsView.pauseAfterChoices.map { seconds in
+            + choices.map { seconds in
                 MenuOption(
                     title: seconds == 0 ? "Never pause" : durationLabel(seconds),
                     checked: overridden && value == seconds
                 ) { store.setPauseAfter(seconds == 0 ? -1 : seconds, for: item) }
             }
             // The list stops at an hour. Anything else this wallpaper wants
-            // is set here, the same way Settings does it.
-            + [.divider, MenuOption(title: "Custom") { customPauseAfter = true }]
+            // is set here, the same way Settings does it. Custom carries the
+            // tick whenever the time is not one of the list's, which includes
+            // a 2 or 15 minute time picked before the list was shortened.
+            + [.divider, MenuOption(
+                title: "Custom",
+                checked: overridden && value > 0 && !choices.contains(value)
+            ) { customPauseAfter = true }]
         }) {
             HStack(spacing: 6) {
                 Image(systemName: "pause.circle")

--- a/Muro/Sources/MuroApp/SettingsView.swift
+++ b/Muro/Sources/MuroApp/SettingsView.swift
@@ -137,6 +137,19 @@ struct SettingsView: View {
                             )) { customPauseAfter = false }
                         }
                     }
+                    // Issue #22. Replay on Clear Desktop belongs to Pause After,
+                    // so no divider sits between the two, it sits closer to
+                    // Pause After than rows sit to each other, and an arrow down
+                    // from Pause After stands where its icon would be. A box
+                    // around the pair was tried first: it pushed both rows in,
+                    // out of line with every other icon and control.
+                    subRow(title: "Replay on Clear Desktop", subtitle: replaySubtitle) {
+                        Toggle("", isOn: Binding(
+                            get: { store.replayOnClearDesktop },
+                            set: { store.setReplayOnClearDesktop($0) }
+                        ))
+                        .toggleStyle(.switch).tint(Color.muroAccent).labelsHidden()
+                    }
                     divider
                     // Apple's setting, offered here so a Mac running Muro as
                     // its screen saver never needs System Settings opened for
@@ -196,6 +209,17 @@ struct SettingsView: View {
                         Toggle("", isOn: Binding(
                             get: { store.autoPauseFullScreen },
                             set: { store.setAutoPauseFullScreen($0) }
+                        ))
+                        .toggleStyle(.switch).tint(Color.muroAccent).labelsHidden()
+                    }
+                    divider
+                    // Issue #22. Any app window open on a screen freezes that
+                    // screen's wallpaper, and a clear desktop plays it.
+                    row(icon: "menubar.dock.rectangle", tint: .blue, title: "Play only on desktop",
+                        subtitle: "Freeze while a window is open on that screen") {
+                        Toggle("", isOn: Binding(
+                            get: { store.playOnlyOnDesktop },
+                            set: { store.setPlayOnlyOnDesktop($0) }
                         ))
                         .toggleStyle(.switch).tint(Color.muroAccent).labelsHidden()
                     }
@@ -411,6 +435,43 @@ struct SettingsView: View {
             .fill(Color.white.opacity(0.06))
             .frame(height: 1)
             .padding(.leading, 58)
+    }
+
+    /// A setting that only changes the row above it. Placed straight after
+    /// that row with no divider, it keeps every measurement of `row`, so its
+    /// arrow, title and control line up with every other row. Only its top
+    /// padding is shorter, which pulls it towards the row it belongs to.
+    private func subRow(
+        title: String, subtitle: String, @ViewBuilder control: () -> some View
+    ) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "arrow.turn.down.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.muroSecondary)
+                .frame(width: 30, height: 30)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white)
+                Text(subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.muroSecondary)
+            }
+            Spacer()
+            control()
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 4)
+        .padding(.bottom, 12)
+    }
+
+    /// Replay has nothing to replay without a time, so it says so while
+    /// Settings has none. A wallpaper with its own Pause After time still
+    /// replays that one.
+    private var replaySubtitle: String {
+        store.pauseAfterSeconds == 0
+            ? "Works with a Pause After time"
+            : "Plays \(durationLabel(store.pauseAfterSeconds)) again each time the desktop clears"
     }
 
     // MARK: - Software update

--- a/Muro/Sources/MuroApp/Store.swift
+++ b/Muro/Sources/MuroApp/Store.swift
@@ -1182,6 +1182,21 @@ final class AppStore: ObservableObject {
         saveConfig()
     }
 
+    /// Issue #22. Both off by default, so no install behaves differently until
+    /// someone turns one on.
+    var playOnlyOnDesktop: Bool { config.playOnlyOnDesktop ?? false }
+    var replayOnClearDesktop: Bool { config.replayOnClearDesktop ?? false }
+
+    func setPlayOnlyOnDesktop(_ on: Bool) {
+        config.playOnlyOnDesktop = on
+        saveConfig()
+    }
+
+    func setReplayOnClearDesktop(_ on: Bool) {
+        config.replayOnClearDesktop = on
+        saveConfig()
+    }
+
     func setAutoPauseLowPower(_ on: Bool) {
         config.autoPauseLowPower = on
         saveConfig()

--- a/Muro/Sources/MuroKit/DesktopCoverage.swift
+++ b/Muro/Sources/MuroKit/DesktopCoverage.swift
@@ -1,0 +1,105 @@
+import CoreGraphics
+import Foundation
+
+/// Issue #22. Which screens have an app window open on them, worked out from
+/// the window list macOS keeps for every process. Only positions and layers
+/// are read, never a window's name or what is in it.
+public enum DesktopCoverage {
+    /// One on-screen window, reduced to what the rule reads.
+    public struct Window: Equatable {
+        public var layer: Int
+        public var bounds: CGRect
+        public var alpha: Double
+
+        public init(layer: Int, bounds: CGRect, alpha: Double) {
+            self.layer = layer
+            self.bounds = bounds
+            self.alpha = alpha
+        }
+    }
+
+    /// In points. A window smaller than this on either side is not something
+    /// anyone reads as covering a desktop. Helper windows some apps keep on
+    /// screen are 1 × 1.
+    public static let minimumSide: CGFloat = 40
+
+    /// Clicking the wallpaper to reveal the desktop does not hide any window.
+    /// It slides each one almost off the screen and leaves a strip of it
+    /// showing at an edge, and the window list reports exactly that. Measured
+    /// on a real Mac on 2026-09-11: strips 13 to 45 points deep, none holding
+    /// even 7% of its window. So a window covers a screen only when a real
+    /// part of it is there: a quarter of the window, or a piece at least
+    /// `minimumPiece` points on both sides. The second rule keeps a very large
+    /// window counting on a screen that shows only a fraction of it.
+    public static let minimumShare: CGFloat = 0.25
+    public static let minimumPiece: CGFloat = 200
+
+    /// Ordinary app windows only. They all sit on layer 0, while the
+    /// wallpaper (Muro's own included), desktop widgets, the Dock, the menu
+    /// bar and floating overlays all sit on other layers. Muro's gallery and
+    /// Settings are app windows, so they count like any other.
+    public static func counts(_ window: Window) -> Bool {
+        window.layer == 0
+            && window.alpha > 0
+            && window.bounds.width >= minimumSide
+            && window.bounds.height >= minimumSide
+    }
+
+    /// Whether enough of a window is on one screen to cover that desktop.
+    public static func covers(_ window: Window, screen frame: CGRect) -> Bool {
+        let overlap = frame.intersection(window.bounds)
+        guard !overlap.isNull, overlap.width > 0, overlap.height > 0,
+              window.bounds.width > 0, window.bounds.height > 0
+        else { return false }
+        let share = (overlap.width * overlap.height) / (window.bounds.width * window.bounds.height)
+        return share >= minimumShare
+            || (overlap.width >= minimumPiece && overlap.height >= minimumPiece)
+    }
+
+    /// Every screen with at least one counting window on it. A window across
+    /// two screens covers both.
+    public static func coveredScreens<Key: Hashable>(
+        windows: [Window], screens: [Key: CGRect]
+    ) -> Set<Key> {
+        var covered = Set<Key>()
+        for window in windows where counts(window) {
+            for (key, frame) in screens where covers(window, screen: frame) {
+                covered.insert(key)
+            }
+        }
+        return covered
+    }
+
+    /// What to hand on after a look, given what was handed on last time.
+    ///
+    /// A screen that has just gone clear is still reported covered until a
+    /// second look agrees, so a window caught mid-animation or halfway between
+    /// Spaces cannot start a wallpaper for a moment, or restart Pause After.
+    /// A screen that has just been covered is reported at once: freezing a
+    /// tenth of a second late would cost nothing, but playing by mistake does.
+    public static func settle<Key: Hashable>(
+        previous: Set<Key>?, current: Set<Key>, confirming: Bool
+    ) -> (report: Set<Key>, needsConfirmation: Bool) {
+        guard let previous, !confirming else { return (current, false) }
+        let cleared = previous.subtracting(current)
+        return cleared.isEmpty ? (current, false) : (current.union(cleared), true)
+    }
+
+    /// The live window list, in the same global coordinates as
+    /// `CGDisplayBounds`, with the origin at the top left of the main display.
+    /// Minimised and hidden windows, and windows on other Spaces, are not on
+    /// screen and are not returned.
+    public static func onScreenWindows() -> [Window] {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let list = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]]
+        else { return [] }
+        return list.compactMap { info in
+            guard let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue,
+                  let dictionary = info[kCGWindowBounds as String] as? NSDictionary,
+                  let bounds = CGRect(dictionaryRepresentation: dictionary as CFDictionary)
+            else { return nil }
+            let alpha = (info[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 1
+            return Window(layer: layer, bounds: bounds, alpha: alpha)
+        }
+    }
+}

--- a/Muro/Sources/MuroKit/DesktopPlayback.swift
+++ b/Muro/Sources/MuroKit/DesktopPlayback.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Issue #22: "Add options/settings to continue playing when desktop is
+/// focused". Two separate switches, both off by default:
+///
+/// - **Play only on desktop** freezes a screen's wallpaper while any app
+///   window is open on that screen, and lets it play while its desktop is
+///   clear. Each screen decides for itself.
+/// - **Replay on clear desktop** makes Pause After count again every time a
+///   screen's desktop becomes clear, so the wallpaper plays for that long and
+///   then freezes. Off, Pause After counts only after a start, an unlock or a
+///   wallpaper change, as it always has.
+///
+/// The rules live here rather than in the window controller so they are
+/// written down and tested, not implied by the order of a few calls.
+public enum DesktopPlayback {
+    /// Whether the engine needs to look at windows at all. Nobody pays for
+    /// the check unless one of the switches is on.
+    public static func needsWindowCheck(playOnlyOnDesktop: Bool, replayOnClearDesktop: Bool) -> Bool {
+        playOnlyOnDesktop || replayOnClearDesktop
+    }
+
+    /// Whether a screen's wallpaper is held because a window is open on it.
+    /// A screen nobody has looked at yet is never held.
+    public static func holds(isCovered: Bool?, playOnlyOnDesktop: Bool) -> Bool {
+        playOnlyOnDesktop && isCovered == true
+    }
+
+    /// Whether this reading makes Pause After count again. Only a real change
+    /// from covered to clear does: the first reading after a start is not the
+    /// desktop clearing, and a desktop that simply stays clear has to be
+    /// allowed to run out and freeze.
+    public static func restartsPauseAfter(
+        wasCovered: Bool?, isCovered: Bool?, replayOnClearDesktop: Bool
+    ) -> Bool {
+        replayOnClearDesktop && wasCovered == true && isCovered == false
+    }
+}

--- a/Muro/Sources/MuroKit/Engine/DesktopWindowMonitor.swift
+++ b/Muro/Sources/MuroKit/Engine/DesktopWindowMonitor.swift
@@ -1,0 +1,140 @@
+import AppKit
+
+/// Issue #22. Looks at the window list while either desktop switch is on and
+/// reports, by display UUID, which screens have an app window open on them.
+///
+/// macOS posts nothing when a window on a screen is minimised or closed, so a
+/// cheap look on a timer is the only way to notice everything without asking
+/// for Accessibility. The timer is the floor, not the speed: a click, an app
+/// switch, a hide, a launch, a quit or a Space change each start a short run
+/// of looks timed to catch windows as they finish opening, closing or sliding
+/// away, so the common cases answer in a few tenths of a second.
+public final class DesktopWindowMonitor {
+    /// Fired on the main queue after every look, with every screen that has an
+    /// app window on it. A display missing from the set has a clear desktop.
+    public var onUpdate: ((Set<String>) -> Void)?
+
+    /// Between events. Short enough that a window closed or minimised from
+    /// the keyboard, which nothing announces, is noticed within half a second.
+    private static let interval: TimeInterval = 0.5
+    /// After a click or an app switch, windows open, close, minimise and slide
+    /// over the next few tenths of a second, so look again as they settle.
+    private static let followUps: [TimeInterval] = [0.1, 0.25, 0.45, 0.75]
+    /// How long a desktop has to stay clear before it is reported clear. See
+    /// `DesktopCoverage.settle`.
+    private static let confirmDelay: TimeInterval = 0.12
+
+    private var timer: Timer?
+    private var observers: [NSObjectProtocol] = []
+    private var clickMonitors: [Any] = []
+    private var followUpLooks: [DispatchWorkItem] = []
+    private var confirmation: DispatchWorkItem?
+    private var reported: Set<String>?
+
+    public init() {}
+
+    deinit { stop() }
+
+    /// Starts looking if it is not already, and looks once straight away
+    /// either way, so a display that has just been added gets its reading.
+    public func start() {
+        if timer == nil {
+            let timer = Timer(timeInterval: Self.interval, repeats: true) { [weak self] _ in self?.look() }
+            timer.tolerance = 0.1
+            RunLoop.main.add(timer, forMode: .common)
+            self.timer = timer
+
+            let center = NSWorkspace.shared.notificationCenter
+            let names: [Notification.Name] = [
+                NSWorkspace.didActivateApplicationNotification,
+                NSWorkspace.didHideApplicationNotification,
+                NSWorkspace.didUnhideApplicationNotification,
+                NSWorkspace.didLaunchApplicationNotification,
+                NSWorkspace.didTerminateApplicationNotification,
+                NSWorkspace.activeSpaceDidChangeNotification,
+            ]
+            for name in names {
+                observers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                    self?.lookAsWindowsSettle()
+                })
+            }
+
+            // Most windows are opened, closed, minimised and revealed with a
+            // click, so a click is the earliest sign that one is about to
+            // change. Only the fact that a click happened is used, never where
+            // it landed or on what. Watching the mouse needs no permission;
+            // watching keys would.
+            let clicks: NSEvent.EventTypeMask = [.leftMouseUp, .rightMouseUp]
+            if let monitor = NSEvent.addGlobalMonitorForEvents(matching: clicks, handler: { [weak self] _ in
+                self?.lookAsWindowsSettle()
+            }) {
+                clickMonitors.append(monitor)
+            }
+            if let monitor = NSEvent.addLocalMonitorForEvents(matching: clicks, handler: { [weak self] event in
+                self?.lookAsWindowsSettle()
+                return event
+            }) {
+                clickMonitors.append(monitor)
+            }
+        }
+        look()
+    }
+
+    public func stop() {
+        timer?.invalidate()
+        timer = nil
+        for observer in observers {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+        observers.removeAll()
+        for monitor in clickMonitors {
+            NSEvent.removeMonitor(monitor)
+        }
+        clickMonitors.removeAll()
+        followUpLooks.forEach { $0.cancel() }
+        followUpLooks.removeAll()
+        confirmation?.cancel()
+        confirmation = nil
+        reported = nil
+    }
+
+    /// Looks now, and again as the windows involved finish moving. A new event
+    /// replaces the looks still waiting from the last one, so a burst of
+    /// clicks costs no more than the clicks themselves.
+    private func lookAsWindowsSettle() {
+        look()
+        followUpLooks.forEach { $0.cancel() }
+        followUpLooks = Self.followUps.map { delay in
+            let item = DispatchWorkItem { [weak self] in self?.look() }
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+            return item
+        }
+    }
+
+    private func look(confirming: Bool = false) {
+        var screens: [String: CGRect] = [:]
+        for screen in NSScreen.screens {
+            guard let uuid = displayUUID(for: screen),
+                  let id = directDisplayID(for: screen)
+            else { continue }
+            screens[uuid] = CGDisplayBounds(id)
+        }
+        let covered = DesktopCoverage.coveredScreens(
+            windows: DesktopCoverage.onScreenWindows(), screens: screens
+        )
+        let next = DesktopCoverage.settle(previous: reported, current: covered, confirming: confirming)
+        reported = next.report
+        onUpdate?(next.report)
+        if next.needsConfirmation { confirmSoon() }
+    }
+
+    private func confirmSoon() {
+        guard confirmation == nil else { return }
+        let item = DispatchWorkItem { [weak self] in
+            self?.confirmation = nil
+            self?.look(confirming: true)
+        }
+        confirmation = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.confirmDelay, execute: item)
+    }
+}

--- a/Muro/Sources/MuroKit/Engine/EngineController.swift
+++ b/Muro/Sources/MuroKit/Engine/EngineController.swift
@@ -14,12 +14,14 @@ public final class EngineController {
     private var configWatcher: DispatchSourceFileSystemObject?
     private var observers: [NSObjectProtocol] = []
     private let power = PowerMonitor()
+    private let desktopWindows = DesktopWindowMonitor()
 
     public init() {}
 
     public func start() {
         power.onChange = { [weak self] in self?.applyPowerState() }
         power.start()
+        desktopWindows.onUpdate = { [weak self] covered in self?.applyDesktopCoverage(covered) }
         reconcile()
         watchConfigDirectory()
         observers.append(NotificationCenter.default.addObserver(
@@ -145,6 +147,34 @@ public final class EngineController {
             controller.setPauseAfter(desired[uuid]?.pauseAfter)
         }
         applyPowerState(config: config)
+        applyDesktopRules(config: config)
+    }
+
+    /// Issue #22. Hands both desktop switches to every display, and keeps the
+    /// window check running only while one of them is on, so nobody pays for
+    /// it otherwise.
+    private func applyDesktopRules(config: EngineConfig) {
+        let playOnlyOnDesktop = config.playOnlyOnDesktop ?? false
+        let replayOnClearDesktop = config.replayOnClearDesktop ?? false
+        for controller in controllers.values {
+            controller.setDesktopRules(
+                playOnlyOnDesktop: playOnlyOnDesktop, replayOnClearDesktop: replayOnClearDesktop
+            )
+        }
+        if DesktopPlayback.needsWindowCheck(
+            playOnlyOnDesktop: playOnlyOnDesktop, replayOnClearDesktop: replayOnClearDesktop
+        ) {
+            desktopWindows.start()
+        } else {
+            desktopWindows.stop()
+            for controller in controllers.values { controller.setDesktopCovered(nil) }
+        }
+    }
+
+    private func applyDesktopCoverage(_ covered: Set<String>) {
+        for (uuid, controller) in controllers {
+            controller.setDesktopCovered(covered.contains(uuid))
+        }
     }
 
     /// Combines the Settings toggles (from config.json) with the live power

--- a/Muro/Sources/MuroKit/Engine/WallpaperWindowController.swift
+++ b/Muro/Sources/MuroKit/Engine/WallpaperWindowController.swift
@@ -51,6 +51,13 @@ public final class WallpaperWindowController {
     /// covered, which costs CPU for something nobody can see, so it stays on
     /// unless the user deliberately turns it off.
     private var autoPauseFullScreen = true
+    /// Issue #22. The two desktop switches from Settings, and whether an app
+    /// window was open on this screen at the engine's last look. Nil until the
+    /// first look, so the first reading is never taken for the desktop
+    /// clearing.
+    private var playOnlyOnDesktop = false
+    private var replayOnClearDesktop = false
+    private var desktopCovered: Bool?
 
     public init(screen: NSScreen, videoURL: URL) {
         window = NSWindow(
@@ -266,6 +273,40 @@ public final class WallpaperWindowController {
     private func settle() {
         settleTimer = nil
         hold("settled")
+    }
+
+    /// Issue #22. "Play only on desktop" is an ordinary hold named
+    /// `desktop-covered`, so it composes with lock, sleep, occlusion and the
+    /// user pause like the rest. "Replay on clear desktop" starts the Pause
+    /// After clock again the moment this screen's desktop clears, the same way
+    /// an unlock does. Neither changes how Pause After counts otherwise.
+    public func setDesktopRules(playOnlyOnDesktop: Bool, replayOnClearDesktop: Bool) {
+        self.replayOnClearDesktop = replayOnClearDesktop
+        guard playOnlyOnDesktop != self.playOnlyOnDesktop else { return }
+        self.playOnlyOnDesktop = playOnlyOnDesktop
+        applyDesktopHold()
+    }
+
+    /// The engine's latest look at this screen: true while an app window is
+    /// open on it, nil while neither switch is on and nothing is looking.
+    public func setDesktopCovered(_ covered: Bool?) {
+        guard covered != desktopCovered else { return }
+        let wasCovered = desktopCovered
+        desktopCovered = covered
+        applyDesktopHold()
+        if DesktopPlayback.restartsPauseAfter(
+            wasCovered: wasCovered, isCovered: covered, replayOnClearDesktop: replayOnClearDesktop
+        ) {
+            armSettleTimer()
+        }
+    }
+
+    private func applyDesktopHold() {
+        if DesktopPlayback.holds(isCovered: desktopCovered, playOnlyOnDesktop: playOnlyOnDesktop) {
+            hold("desktop-covered")
+        } else {
+            release("desktop-covered")
+        }
     }
 
     /// Playback speed from Settings (0.5×–1.5×). Applied live when playing.

--- a/Muro/Sources/MuroKit/EngineConfig.swift
+++ b/Muro/Sources/MuroKit/EngineConfig.swift
@@ -34,6 +34,15 @@ public struct EngineConfig: Codable {
     /// frame (nil or 0 = never freeze). Issue #3: fast wallpapers are
     /// distracting, so let them move briefly and then settle.
     public var pauseAfterSeconds: Int?
+    /// Issue #22, "Play only on desktop". Freeze a display's wallpaper while
+    /// any app window is open on that display, and play it only while its
+    /// desktop is clear (nil = false, so every existing install is unchanged).
+    public var playOnlyOnDesktop: Bool?
+    /// Issue #22, the Pause After half. Every time a display's desktop becomes
+    /// clear, Pause After counts again, so the wallpaper plays for that long
+    /// and then freezes. Off (nil = false), Pause After counts only after a
+    /// start, an unlock or a wallpaper change, as it always has.
+    public var replayOnClearDesktop: Bool?
 
     public init(allDisplays: Assignment? = nil, perDisplay: [String: Assignment] = [:]) {
         self.allDisplays = allDisplays

--- a/Muro/Tests/MuroKitTests/DesktopCoverageTests.swift
+++ b/Muro/Tests/MuroKitTests/DesktopCoverageTests.swift
@@ -1,0 +1,164 @@
+import CoreGraphics
+import XCTest
+@testable import MuroKit
+
+/// Issue #22. The layers and sizes below are the ones a real Mac reported on
+/// 2026-09-11: a 1470 × 956 built-in screen with Finder, Safari and Terminal
+/// open, desktop widgets, the menu bar, the Dock and a floating overlay.
+final class DesktopCoverageTests: XCTestCase {
+    typealias Window = DesktopCoverage.Window
+
+    let builtIn = CGRect(x: 0, y: 0, width: 1470, height: 956)
+    /// An external display to the right of it.
+    let external = CGRect(x: 1470, y: 0, width: 1920, height: 1080)
+
+    var screens: [String: CGRect] { ["built-in": builtIn, "external": external] }
+
+    func appWindow(_ x: CGFloat, _ y: CGFloat, _ width: CGFloat, _ height: CGFloat) -> Window {
+        Window(layer: 0, bounds: CGRect(x: x, y: y, width: width, height: height), alpha: 1)
+    }
+
+    // MARK: Which screen a window covers
+
+    func testNoWindowsMeansEveryDesktopIsClear() {
+        XCTAssertEqual(DesktopCoverage.coveredScreens(windows: [], screens: screens), [])
+    }
+
+    func testAWindowCoversOnlyTheScreenItIsOn() {
+        let safari = appWindow(93, 167, 1272, 794)
+        XCTAssertEqual(DesktopCoverage.coveredScreens(windows: [safari], screens: screens), ["built-in"])
+    }
+
+    func testAWindowOnTheExternalScreenLeavesTheBuiltInScreenClear() {
+        let window = appWindow(1600, 100, 800, 600)
+        XCTAssertEqual(DesktopCoverage.coveredScreens(windows: [window], screens: screens), ["external"])
+    }
+
+    func testAWindowAcrossBothScreensCoversBoth() {
+        let window = appWindow(1000, 100, 1000, 600)
+        XCTAssertEqual(
+            DesktopCoverage.coveredScreens(windows: [window], screens: screens),
+            ["built-in", "external"]
+        )
+    }
+
+    func testAFewPointsHangingOverTheEdgeDoNotCoverTheNextScreen() {
+        // 20 points of it reach onto the external screen.
+        let window = appWindow(500, 100, 990, 600)
+        XCTAssertEqual(DesktopCoverage.coveredScreens(windows: [window], screens: screens), ["built-in"])
+    }
+
+    func testAScreenAboveTheMainOneIsFoundInNegativeCoordinates() {
+        let above = CGRect(x: 0, y: -1080, width: 1920, height: 1080)
+        let window = appWindow(200, -900, 800, 600)
+        XCTAssertEqual(
+            DesktopCoverage.coveredScreens(windows: [window], screens: ["built-in": builtIn, "above": above]),
+            ["above"]
+        )
+    }
+
+    func testAWindowOffEveryScreenCoversNothing() {
+        let window = appWindow(5000, 5000, 800, 600)
+        XCTAssertEqual(DesktopCoverage.coveredScreens(windows: [window], screens: screens), [])
+    }
+
+    func testABigPieceOfAWindowCoversAScreenEvenWhenMostOfItIsElsewhere() {
+        // 3000 points wide with a 700 × 700 piece on the built-in screen: under
+        // a quarter of the window, but plainly covering that desktop.
+        let window = appWindow(770, 100, 3000, 700)
+        XCTAssertEqual(
+            DesktopCoverage.coveredScreens(windows: [window], screens: screens),
+            ["built-in", "external"]
+        )
+    }
+
+    // MARK: Clicking the wallpaper to reveal the desktop
+
+    func testTheStripsLeftByRevealingTheDesktopLeaveItClear() {
+        // The window list a real Mac reported while the desktop was revealed:
+        // every window slid almost off the screen, a strip of each at an edge.
+        let revealed = [
+            appWindow(-753, -583, 920, 628),   // Finder, 167 × 45 in the top left corner
+            appWindow(-69, -573, 1100, 618),   // Terminal, 1031 × 45 along the top
+            appWindow(26, 943, 1272, 794),     // Safari, 1272 × 13 along the bottom
+        ]
+        XCTAssertEqual(DesktopCoverage.coveredScreens(windows: revealed, screens: screens), [])
+    }
+
+    func testTheSameWindowsBackInPlaceCoverTheScreenAgain() {
+        let inPlace = [
+            appWindow(180, 110, 920, 628),
+            appWindow(153, 90, 1100, 618),
+            appWindow(93, 167, 1272, 794),
+        ]
+        XCTAssertEqual(DesktopCoverage.coveredScreens(windows: inPlace, screens: screens), ["built-in"])
+    }
+
+    // MARK: What does not count
+
+    func testTheWallpaperWidgetsDockMenuBarAndOverlaysDoNotCount() {
+        let full = CGRect(x: 0, y: 0, width: 1470, height: 956)
+        let notAppWindows = [
+            Window(layer: -2147483604, bounds: full, alpha: 1),                                      // Muro's wallpaper
+            Window(layer: -2147483603, bounds: full, alpha: 1),                                      // Finder's desktop
+            Window(layer: -2147483601, bounds: CGRect(x: 4, y: 39, width: 180, height: 180), alpha: 1), // a desktop widget
+            Window(layer: 20, bounds: full, alpha: 1),                                               // the Dock
+            Window(layer: 24, bounds: CGRect(x: 0, y: 0, width: 1470, height: 33), alpha: 1),        // the menu bar
+            Window(layer: 25, bounds: CGRect(x: 1003, y: 0, width: 169, height: 33), alpha: 1),      // a menu bar item
+            Window(layer: 1000, bounds: CGRect(x: 479, y: 278, width: 512, height: 586), alpha: 1),  // a floating overlay
+        ]
+        XCTAssertEqual(DesktopCoverage.coveredScreens(windows: notAppWindows, screens: screens), [])
+    }
+
+    func testAFullyTransparentWindowDoesNotCount() {
+        let window = Window(layer: 0, bounds: CGRect(x: 100, y: 100, width: 800, height: 600), alpha: 0)
+        XCTAssertFalse(DesktopCoverage.counts(window))
+    }
+
+    func testATinyHelperWindowDoesNotCount() {
+        XCTAssertFalse(DesktopCoverage.counts(appWindow(700, 400, 1, 1)))
+    }
+
+    func testASmallRealWindowStillCounts() {
+        // About the size of Calculator.
+        XCTAssertTrue(DesktopCoverage.counts(appWindow(700, 300, 230, 400)))
+    }
+
+    // MARK: Settling one look into what is reported
+
+    func testTheFirstLookIsReportedAsItIs() {
+        let result = DesktopCoverage.settle(previous: nil, current: ["built-in"], confirming: false)
+        XCTAssertEqual(result.report, ["built-in"])
+        XCTAssertFalse(result.needsConfirmation)
+    }
+
+    func testANewlyCoveredScreenIsReportedAtOnce() {
+        let result = DesktopCoverage.settle(previous: [], current: ["built-in"], confirming: false)
+        XCTAssertEqual(result.report, ["built-in"])
+        XCTAssertFalse(result.needsConfirmation)
+    }
+
+    func testANewlyClearScreenWaitsForASecondLook() {
+        let result = DesktopCoverage.settle(previous: ["built-in"], current: [], confirming: false)
+        XCTAssertEqual(result.report, ["built-in"])
+        XCTAssertTrue(result.needsConfirmation)
+    }
+
+    func testTheSecondLookReportsItClear() {
+        let result = DesktopCoverage.settle(previous: ["built-in"], current: [], confirming: true)
+        XCTAssertEqual(result.report, [])
+        XCTAssertFalse(result.needsConfirmation)
+    }
+
+    func testAWindowBackByTheSecondLookKeepsTheScreenCovered() {
+        let result = DesktopCoverage.settle(previous: ["built-in"], current: ["built-in"], confirming: true)
+        XCTAssertEqual(result.report, ["built-in"])
+        XCTAssertFalse(result.needsConfirmation)
+    }
+
+    func testOneScreenClearingDoesNotHoldBackAnotherBeingCovered() {
+        let result = DesktopCoverage.settle(previous: ["built-in"], current: ["external"], confirming: false)
+        XCTAssertEqual(result.report, ["built-in", "external"])
+        XCTAssertTrue(result.needsConfirmation)
+    }
+}

--- a/Muro/Tests/MuroKitTests/DesktopPlaybackTests.swift
+++ b/Muro/Tests/MuroKitTests/DesktopPlaybackTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import MuroKit
+
+/// Issue #22. Two switches, both off by default, and one mixed case that is
+/// easy to get wrong: Play only on desktop on, Replay off, Pause After set.
+final class DesktopPlaybackTests: XCTestCase {
+
+    // MARK: Nothing changes unless a switch is on
+
+    func testWithBothSwitchesOffNothingLooksAtWindows() {
+        XCTAssertFalse(DesktopPlayback.needsWindowCheck(playOnlyOnDesktop: false, replayOnClearDesktop: false))
+    }
+
+    func testEitherSwitchIsEnoughToLook() {
+        XCTAssertTrue(DesktopPlayback.needsWindowCheck(playOnlyOnDesktop: true, replayOnClearDesktop: false))
+        XCTAssertTrue(DesktopPlayback.needsWindowCheck(playOnlyOnDesktop: false, replayOnClearDesktop: true))
+    }
+
+    func testAConfigWrittenBeforeTheSwitchesLeavesBothOff() throws {
+        let config = try JSONDecoder().decode(EngineConfig.self, from: Data(#"{"perDisplay":{}}"#.utf8))
+        XCTAssertNil(config.playOnlyOnDesktop)
+        XCTAssertNil(config.replayOnClearDesktop)
+    }
+
+    // MARK: Play only on desktop
+
+    func testAWindowOnTheScreenHoldsItsWallpaper() {
+        XCTAssertTrue(DesktopPlayback.holds(isCovered: true, playOnlyOnDesktop: true))
+    }
+
+    func testAClearDesktopPlays() {
+        XCTAssertFalse(DesktopPlayback.holds(isCovered: false, playOnlyOnDesktop: true))
+    }
+
+    func testWithTheSwitchOffAWindowHoldsNothing() {
+        XCTAssertFalse(DesktopPlayback.holds(isCovered: true, playOnlyOnDesktop: false))
+    }
+
+    func testAScreenNobodyHasLookedAtIsNotHeld() {
+        XCTAssertFalse(DesktopPlayback.holds(isCovered: nil, playOnlyOnDesktop: true))
+    }
+
+    // MARK: Replay on clear desktop
+
+    func testTheDesktopClearingMakesPauseAfterCountAgain() {
+        XCTAssertTrue(DesktopPlayback.restartsPauseAfter(wasCovered: true, isCovered: false, replayOnClearDesktop: true))
+    }
+
+    func testWithReplayOffTheDesktopClearingLeavesPauseAfterAlone() {
+        // The mixed case. Pause After counts only after a start, an unlock or
+        // a new wallpaper, so once it has frozen the wallpaper, a clear
+        // desktop leaves it frozen.
+        XCTAssertFalse(DesktopPlayback.restartsPauseAfter(wasCovered: true, isCovered: false, replayOnClearDesktop: false))
+    }
+
+    func testADesktopThatStaysClearIsAllowedToFreeze() {
+        XCTAssertFalse(DesktopPlayback.restartsPauseAfter(wasCovered: false, isCovered: false, replayOnClearDesktop: true))
+    }
+
+    func testTheFirstReadingIsNotTheDesktopClearing() {
+        XCTAssertFalse(DesktopPlayback.restartsPauseAfter(wasCovered: nil, isCovered: false, replayOnClearDesktop: true))
+    }
+
+    func testOpeningAWindowDoesNotMakePauseAfterCount() {
+        XCTAssertFalse(DesktopPlayback.restartsPauseAfter(wasCovered: false, isCovered: true, replayOnClearDesktop: true))
+    }
+
+    func testTurningTheCheckOffIsNotTheDesktopClearing() {
+        XCTAssertFalse(DesktopPlayback.restartsPauseAfter(wasCovered: true, isCovered: nil, replayOnClearDesktop: true))
+    }
+}


### PR DESCRIPTION
Raised in #22.

Two new switches in Settings, both off by default.

**Play only on desktop** (ENERGY): while any app window is open on a screen, that screen's wallpaper holds on a frame, and a clear desktop plays it. Each display decides for itself, so a window on the laptop screen leaves an external monitor playing. Minimising everything, closing everything, or clicking the wallpaper to reveal the desktop all count as clear.

**Replay on Clear Desktop** (under Pause After): every time a screen's desktop becomes clear, Pause After counts again, so the wallpaper plays for that long and then holds. With it off, Pause After counts only after a start, an unlock or a wallpaper change, as before. Each wallpaper's own Pause After time is the one used.

How it notices: macOS announces nothing when the last window is minimised or closed, so the engine looks at the window list twice a second while either switch is on, and straight away after a click, an app switch, a hide, a launch, a quit or a Space change, with a few follow-up looks as windows finish moving. It reads window positions and layers only, never names or contents, and only the fact that a click happened, never where it landed. One look costs about a millisecond, and nothing runs at all while both switches are off.

Clicking the wallpaper to reveal the desktop does not hide windows: macOS slides them almost off the screen and leaves a strip at an edge, so a window counts for a display only when a quarter of it, or a piece at least 200 by 200 points, is on it.

The Pause After menu on a wallpaper's page is shorter: Use setting, Never pause, 10 s, 30 s, 1 min, 5 min, 1 h and Custom. The list in Settings is unchanged.

210 tests pass.
